### PR TITLE
use absolute paths for cadence scripts

### DIFF
--- a/src/hammer-vlsi/par/innovus/__init__.py
+++ b/src/hammer-vlsi/par/innovus/__init__.py
@@ -120,7 +120,7 @@ $INNOVUS_BIN -common_ui -files generated-scripts/open_chip.tcl
             self.get_setting("par.innovus.innovus_bin"),
             "-nowin",  # Prevent the GUI popping up.
             "-common_ui",
-            "-files", par_tcl_filename
+            "-files", os.path.abspath(par_tcl_filename)
         ]
 
         # Temporarily disable colours/tag to make run output more readable.

--- a/src/hammer-vlsi/synthesis/genus/__init__.py
+++ b/src/hammer-vlsi/synthesis/genus/__init__.py
@@ -105,7 +105,7 @@ class Genus(HammerSynthesisTool, CadenceTool):
         # Build args.
         args = [
             self.get_setting("synthesis.genus.genus_bin"),
-            "-f", syn_tcl_filename
+            "-f", os.path.abspath(syn_tcl_filename)
         ]
 
         # Temporarily disable colours/tag to make run output more readable.

--- a/src/hammer-vlsi/synthesis/genus/__init__.py
+++ b/src/hammer-vlsi/synthesis/genus/__init__.py
@@ -67,12 +67,12 @@ class Genus(HammerSynthesisTool, CadenceTool):
         clock_constraints_fragment = os.path.join(self.run_dir, "clock_constraints_fragment.sdc")
         with open(clock_constraints_fragment, "w") as f:
             f.write(self.sdc_clock_constraints)
-        constraint_files.append(clock_constraints_fragment)
+        constraint_files.append(os.path.abspath(clock_constraints_fragment))
         # Generate port constraints.
         pin_constraints_fragment = os.path.join(self.run_dir, "pin_constraints_fragment.sdc")
         with open(pin_constraints_fragment, "w") as f:
             f.write(self.sdc_pin_constraints)
-        constraint_files.append(pin_constraints_fragment)
+        constraint_files.append(os.path.abspath(pin_constraints_fragment))
 
         verbose_append("create_constraint_mode -name func -sdc_files [list {}]".format(" ".join(constraint_files)))
         # Apparently it also needs to be sourced to work?


### PR DESCRIPTION
It seems like cadence tools don't like non-absolute paths or its just in the wrong place, either way this seems like a good solution.