### PR TITLE
add gitignore for using hammer dir as obj-dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,17 @@
+# Text editors / IDEs
 *.swp
 .idea
 
-/bin
-/obj
-/check
-/trace
-/Makefile.local
-
+# Hammer outputs
 *.log
 *rundir/
 /*.json
 
-/DVEfiles
-/opendatabase.log
-
+# Python junk
 __pycache__
 *.pyc
 .mypy_cache
+
+# Misc / unknown?
+/DVEfiles
+/opendatabase.log

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 /trace
 /Makefile.local
 
+*.log
+*rundir/
+/*.json
+
 /DVEfiles
 /opendatabase.log
 


### PR DESCRIPTION
This makes git status clean if you set `--obj-dir $PWD`