### PR TITLE
Use line buffering in popen

### DIFF
--- a/src/hammer-vlsi/hammer_vlsi.py
+++ b/src/hammer-vlsi/hammer_vlsi.py
@@ -1217,12 +1217,12 @@ class HammerTool(metaclass=ABCMeta):
         prog_tag = prog_name + " " + prog_args
         subprocess_logger = self.logger.context("Exec " + prog_tag)
 
-        proc = subprocess.Popen(args, bufsize=1, shell=False, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, env=self._subprocess_env, cwd=cwd)
+        proc = subprocess.Popen(args, bufsize=1, shell=False, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, env=self._subprocess_env, cwd=cwd, universal_newlines=True)
         atexit.register(proc.kill)
         # Log output and also capture output at the same time.
         output_buf = ""
         while True:
-            line = proc.stdout.readline().decode("utf-8")
+            line = proc.stdout.readline()
             if line != '':
                 subprocess_logger.debug(line.rstrip())
                 output_buf += line

--- a/src/hammer-vlsi/hammer_vlsi.py
+++ b/src/hammer-vlsi/hammer_vlsi.py
@@ -1216,7 +1216,7 @@ class HammerTool(metaclass=ABCMeta):
         prog_tag = prog_name + " " + prog_args
         subprocess_logger = self.logger.context("Exec " + prog_tag)
 
-        proc = subprocess.Popen(args, shell=False, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, env=self._subprocess_env, cwd=cwd)
+        proc = subprocess.Popen(args, bufsize=1, shell=False, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, env=self._subprocess_env, cwd=cwd)
         # Log output and also capture output at the same time.
         output_buf = ""
         while True:


### PR DESCRIPTION
This makes it easier to tail hammer's output if using lsf or something else.
Some cad commands take a long time and so not knowing exactly which line hammer is on can be confusing.

Also this linebreak at the end keeps coming up in my diffs so maybe our editors are fighting, and we'll see if mine wins ;)

Closes #64 