### PR TITLE
add orientation support to floorplan json

### DIFF
--- a/src/hammer-vlsi/hammer_vlsi.py
+++ b/src/hammer-vlsi/hammer_vlsi.py
@@ -483,6 +483,7 @@ PlacementConstraint = NamedTuple('PlacementConstraint', [
     ('y', float),
     ('width', float),
     ('height', float),
+    ('orientation', Optional[str]),
     ('margins', Optional[Margins])
 ])
 
@@ -1589,6 +1590,7 @@ class HammerTool(metaclass=ABCMeta):
         for constraint in constraints:
             constraint_type = PlacementConstraintType.from_string(str(constraint["type"]))
             margins = None  # type: Optional[Margins]
+            orientation = None # type: Optional[str]
             if constraint_type == PlacementConstraintType.TopLevel:
                 margins_dict = constraint["margins"]
                 margins = Margins(
@@ -1597,6 +1599,8 @@ class HammerTool(metaclass=ABCMeta):
                     right=float(margins_dict["right"]),
                     top=float(margins_dict["top"])
                 )
+            if "orientation" in constraint:
+                orientation = str(constraint["orientation"])
             load = PlacementConstraint(
                 path=str(constraint["path"]),
                 type=constraint_type,
@@ -1604,6 +1608,7 @@ class HammerTool(metaclass=ABCMeta):
                 y=float(constraint["y"]),
                 width=float(constraint["width"]),
                 height=float(constraint["height"]),
+                orientation=orientation,
                 margins=margins
             )
             output.append(load)


### PR DESCRIPTION
Did this a while ago but forgot to PR it.

I'm not sure if the strings are tech or tool specific so if we figure that out we might want a config that maps between independent versions and the specific ones.