### PR TITLE
Revamp load_tool to take the class object instead of an instance

### DIFF
--- a/src/hammer-vlsi/README.md
+++ b/src/hammer-vlsi/README.md
@@ -26,9 +26,10 @@ export PATH="$HAMMER_HOME/src/hammer-shell:$PATH"
 Tool library system
 ===================
 
-hammer-vlsi imports libraries as python modules. For example, if dc was a tool, it would be either 1) a folder named "dc" with __init__.py which follows the given format; 2) a file named dc.py which follows the given format.
+hammer-vlsi imports libraries as Python modules. For example, if dc was a tool, it would be either 1) a folder named "dc" with __init__.py which follows the given format; 2) a file named dc.py which follows the given format.
 
-The module should contain an object named 'tool', since hammer-vlsi will do "import dc.tool", for example. `tool` should be an instance of an appropriate subclass of HammerTool (e.g. HammerSynthesisTool).
+The module should contain an class object named 'tool', since hammer-vlsi will do `import dc.tool`, for example, and use it to create an instance of the tool.
+`tool` should be a class object of an appropriate subclass of HammerTool (e.g. `HammerSynthesisTool`).
 
 Technology library system
 =========================

--- a/src/hammer-vlsi/hammer_vlsi.py
+++ b/src/hammer-vlsi/hammer_vlsi.py
@@ -2427,16 +2427,17 @@ def load_tool(tool_name: str, path: Iterable[str]) -> HammerTool:
     for _ in path:
         sys.path.pop(0)
     try:
-        htool = getattr(mod, "tool")
+        tool_class = getattr(mod, "tool")
     except AttributeError:
         raise ValueError("No such tool " + tool_name + ", or tool does not follow the hammer-vlsi tool library format")
 
-    if not isinstance(htool, HammerTool):
+    if not issubclass(tool_class, HammerTool):
         raise ValueError("Tool must be a HammerTool")
 
     # Set the tool directory.
-    htool.tool_dir = os.path.dirname(os.path.abspath(mod.__file__))
-    return htool
+    tool = tool_class()
+    tool.tool_dir = os.path.dirname(os.path.abspath(mod.__file__))
+    return tool
 
 
 def reduce_named(function: Callable, sequence: Iterable, initial=None) -> Any:

--- a/src/hammer-vlsi/par/nop.py
+++ b/src/hammer-vlsi/par/nop.py
@@ -17,4 +17,4 @@ class Nop(HammerPlaceAndRouteTool):
         return []
 
 
-tool = Nop()
+tool = Nop

--- a/src/hammer-vlsi/synthesis/mocksynth/__init__.py
+++ b/src/hammer-vlsi/synthesis/mocksynth/__init__.py
@@ -83,4 +83,4 @@ class MockSynth(HammerSynthesisTool):
         return True
 
 
-tool = MockSynth()
+tool = MockSynth


### PR DESCRIPTION
In preparation for hierarchical which may perform multiple invocations
of the same tool in the same process, and we want to avoid the risk of
variables not being reset between runs.