### PR TITLE
Adding quotes to the path.tcl template.

### DIFF
--- a/src/hammer-vlsi/synthesis/vivado/file_templates/paths.tcl
+++ b/src/hammer-vlsi/synthesis/vivado/file_templates/paths.tcl
@@ -5,6 +5,6 @@ set_param board.repoPaths [list {board_files}];
 set scriptdir {work_dir};
 set wrkdir [file join $scriptdir obj]
 set dcpdir {dcp_macro_dir};
-set srcmainverilogfile {verilog_files};
-set srcmainverilogfiles {verilog_files};
+set srcmainverilogfile "{verilog_files}";
+set srcmainverilogfiles "{verilog_files}";
 set top {top_module}


### PR DESCRIPTION
This makes it OK to have multiple verilog sources.