### PR TITLE
Call super().env_vars in *Tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.log
 *rundir/
 /*.json
+src/test/output.json
 
 # Sphinx/doc junk
 doc/_build/

--- a/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py
@@ -612,11 +612,13 @@ class SynopsysTool(HasSDCSupport, HammerTool):
         Get the list of environment variables required for this tool.
         Note to subclasses: remember to include variables from super().env_vars!
         """
-        return {
+        result = dict(super().env_vars)
+        result.update({
             "SNPSLMD_LICENSE_FILE": self.get_setting("synopsys.SNPSLMD_LICENSE_FILE"),
             # TODO: this is actually a Mentor Graphics licence, not sure why the old dc scripts depend on it.
             "MGLS_LICENSE_FILE": self.get_setting("synopsys.MGLS_LICENSE_FILE")
-        }
+        })
+        return result
 
     def version_number(self, version: str) -> int:
         """

--- a/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py
@@ -411,7 +411,7 @@ class CadenceTool(HasSDCSupport, HammerTool):
             tmp.update(new)
             return tmp
 
-        return reduce(update_dict, list_of_vars + [cadence_vars], {})
+        return reduce(update_dict, [dict(super().env_vars)] + list_of_vars + [cadence_vars], {})
 
     def version_number(self, version: str) -> int:
         """


### PR DESCRIPTION
Currently the parent classes of SynopsysTool and CadenceTool have empty sets for env_vars, but these could squash the env_vars of other traits in multiply-inherited subclasses.