### PR TITLE
First pass implementation of submission commands

### DIFF
--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -180,7 +180,8 @@ vlsi.inputs:
 vlsi.submit:
   # The submit command to use. "none", "local", or null will run on the current host. See hammer_submit_command.py for other options.
   command: "local"
-  # This should be a List[Dict[str, Dict[str, Any]]]. The list substitutes settings in order of appearance, and the first Dict key is the command.
+  # type: List[Dict[str, Dict[str, Any]]]
+  # The list substitutes settings in order of appearance, and the first Dict key is the command.
   # The second dict key is the name of that command's setting, followed by whatever type it takes.
   settings: []
 

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -183,7 +183,7 @@ vlsi.submit:
   # This should be a List[Dict[str, Dict[str, Any]]]. The list substitutes settings in order of appearance, and the first Dict key is the command.
   # The second dict key is the name of that command's setting, followed by whatever type it takes.
   settings: [
-    { "none": {"foo": null} } # TODO: {"foo": null} should be {} but there is a parser bug here
+    { "none": {} }
     ]
 
 # Specific inputs for the synthesis tool.

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -190,7 +190,6 @@ synthesis.inputs:
   # Set to null to not specify from the JSON.
   top_module: null
 
-
 # Specific inputs for the place and route tool.
 # These inputs are the generic inputs; specific tools ("CAD junk") may require
 # additional inputs.
@@ -225,3 +224,10 @@ par.inputs:
   # the final GDS.
   # type: bool
   gds_merge: false
+
+# The submit command to use. "none", "bare", or null will run on the current host. See hammer_submit_command.py for other options.
+synthesis.submit_command: "none"
+synthesis.submit_command_settings: null
+par.submit_command: "none"
+par.submit_command_settings: null
+

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -177,6 +177,15 @@ vlsi.inputs:
   # type: List[str]
   dont_use_list: []
 
+vlsi.submit:
+  # The submit command to use. "none", "local", or null will run on the current host. See hammer_submit_command.py for other options.
+  command: "none"
+  # This should be a List[Dict[str, Dict[str, Any]]]. The list substitutes settings in order of appearance, and the first Dict key is the command.
+  # The second dict key is the name of that command's setting, followed by whatever type it takes.
+  settings: [
+    { "none": {"foo": null} } # TODO: {"foo": null} should be {} but there is a parser bug here
+    ]
+
 # Specific inputs for the synthesis tool.
 # These inputs are the generic inputs; specific tools ("CAD junk") may require
 # additional inputs.
@@ -189,6 +198,13 @@ synthesis.inputs:
   # Top RTL module.
   # Set to null to not specify from the JSON.
   top_module: null
+
+# inherit settings from vlsi.submit but allow us to override them
+synthesis.submit:
+  command: "${vlsi.submit.command}"
+  command_meta: dynamicsubst
+  settings: []
+  settings_meta: append
 
 # Specific inputs for the place and route tool.
 # These inputs are the generic inputs; specific tools ("CAD junk") may require
@@ -225,9 +241,9 @@ par.inputs:
   # type: bool
   gds_merge: false
 
-# The submit command to use. "none", "bare", or null will run on the current host. See hammer_submit_command.py for other options.
-synthesis.submit_command: "none"
-synthesis.submit_command_settings: null
-par.submit_command: "none"
-par.submit_command_settings: null
-
+# inherit settings from vlsi.submit but allow us to override them
+par.submit:
+  command: "${vlsi.submit.command}"
+  command_meta: dynamicsubst
+  settings: []
+  settings_meta: append

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -179,12 +179,10 @@ vlsi.inputs:
 
 vlsi.submit:
   # The submit command to use. "none", "local", or null will run on the current host. See hammer_submit_command.py for other options.
-  command: "none"
+  command: "local"
   # This should be a List[Dict[str, Dict[str, Any]]]. The list substitutes settings in order of appearance, and the first Dict key is the command.
   # The second dict key is the name of that command's setting, followed by whatever type it takes.
-  settings: [
-    { "none": {} }
-    ]
+  settings: []
 
 # Specific inputs for the synthesis tool.
 # These inputs are the generic inputs; specific tools ("CAD junk") may require

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -202,7 +202,6 @@ synthesis.submit:
   command: "${vlsi.submit.command}"
   command_meta: dynamicsubst
   settings: []
-  settings_meta: append
 
 # Specific inputs for the place and route tool.
 # These inputs are the generic inputs; specific tools ("CAD junk") may require
@@ -244,4 +243,3 @@ par.submit:
   command: "${vlsi.submit.command}"
   command_meta: dynamicsubst
   settings: []
-  settings_meta: append

--- a/src/hammer-vlsi/hammer_vlsi/__init__.py
+++ b/src/hammer-vlsi/hammer_vlsi/__init__.py
@@ -23,3 +23,5 @@ from .driver import *
 from .verilog_utils import *
 
 from .cli_driver import CLIDriver
+
+from .submit_command import *

--- a/src/hammer-vlsi/hammer_vlsi/driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/driver.py
@@ -21,7 +21,7 @@ from .hooks import HammerToolHookAction
 from .hammer_vlsi_impl import HammerVLSISettings, HammerPlaceAndRouteTool, HammerSynthesisTool, \
     HierarchicalMode, load_tool, PlacementConstraint
 from hammer_logging import HammerVLSIFileLogger, HammerVLSILogging, HammerVLSILoggingContext
-from .hammer_submit_command import HammerSubmitCommand
+from .submit_command import HammerSubmitCommand
 
 __all__ = ['HammerDriverOptions', 'HammerDriver']
 

--- a/src/hammer-vlsi/hammer_vlsi/driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/driver.py
@@ -21,6 +21,7 @@ from .hooks import HammerToolHookAction
 from .hammer_vlsi_impl import HammerVLSISettings, HammerPlaceAndRouteTool, HammerSynthesisTool, \
     HierarchicalMode, load_tool, PlacementConstraint
 from hammer_logging import HammerVLSIFileLogger, HammerVLSILogging, HammerVLSILoggingContext
+from .hammer_submit_command import HammerSubmitCommand
 
 __all__ = ['HammerDriverOptions', 'HammerDriver']
 
@@ -212,6 +213,7 @@ class HammerDriver:
             self.database.get_setting("vlsi.inputs.hierarchical.mode"))
         syn_tool.input_files = self.database.get_setting("synthesis.inputs.input_files")
         syn_tool.top_module = self.database.get_setting("synthesis.inputs.top_module", nullvalue="")
+        syn_tool.submit_command = HammerSubmitCommand.get("synthesis", self.database)
 
         # TODO: automate this based on the definitions
         missing_inputs = False
@@ -255,6 +257,7 @@ class HammerDriver:
         par_tool.run_dir = run_dir
         par_tool.hierarchical_mode = HierarchicalMode.from_str(
             self.database.get_setting("vlsi.inputs.hierarchical.mode"))
+        par_tool.submit_command = HammerSubmitCommand.get("par", self.database)
 
         missing_inputs = False
 

--- a/src/hammer-vlsi/hammer_vlsi/hammer_submit_command.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_submit_command.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# hammer_submit_command.py
+#
+
+from abc import ABCMeta, abstractmethod
+import atexit
+import subprocess
+from typing import Callable, Iterable, List, NamedTuple, Optional, Dict, Any, Union
+from hammer_logging import HammerVLSIFileLogger, HammerVLSILogging, HammerVLSILoggingContext
+
+class HammerSubmitCommand:
+
+    @abstractmethod
+    def submit(self, args: List[str], env: Dict[str,str], logger: HammerVLSILoggingContext, cwd: str = None) -> str:
+        """
+        Submit the job to the job submission system. This function MUST block until the command is complete.
+
+        :param args: Command-line to run; each item in the list is one token. The first token should be the command to run.
+        :param env: The environment variables to set for the command
+        :param logger: The logging context
+        :param cwd: Working directory (leave as None to use the current working directory).
+        :return: The command output
+        """
+        pass
+
+
+class HammerBareSubmitCommand(HammerSubmitCommand):
+
+    def submit(self, args: List[str], env: Dict[str,str], logger: HammerVLSILoggingContext, cwd: str = None) -> str:
+        """
+        Submit the job to the job submission system. This function MUST block until the command is complete.
+        This implementation just runs the command on the host.
+
+        :param args: Command-line to run; each item in the list is one token. The first token should be the command to run.
+        :param env: The environment variables to set for the command
+        :param logger: The logging context
+        :param cwd: Working directory (leave as None to use the current working directory).
+        :return: The command output
+        """
+        # Short version for easier display in the log.
+        PROG_NAME_LEN = 14 # Capture last 14 characters of the command name
+        if len(args[0]) <= PROG_NAME_LEN:
+            prog_name = args[0]
+        else:
+            prog_name = "..." + args[0][len(args[0])-PROG_NAME_LEN:]
+        remaining_args = " ".join(args[1:])
+        if len(remaining_args) <= 15:
+            prog_args = remaining_args
+        else:
+            prog_args = remaining_args[0:15] + "..."
+        prog_tag = prog_name + " " + prog_args
+
+        output_buf = ""
+
+        logger.debug("Executing subprocess: " + ' '.join(args))
+        subprocess_logger = logger.context("Exec " + prog_tag)
+        proc = subprocess.Popen(args, shell=False, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, env=env, cwd=cwd)
+        atexit.register(proc.kill)
+        # Log output and also capture output at the same time.
+        while True:
+            line = proc.stdout.readline().decode("utf-8")
+            if line != '':
+                subprocess_logger.debug(line.rstrip())
+                output_buf += line
+            else:
+                break
+        # TODO: check errors
+
+        return output_buf
+
+class HammerLSFSubmitCommand(HammerSubmitCommand):
+
+    @property
+    def bsub_binary(self) -> str:
+        """ Get the LSF bsub binary location """
+        try:
+            return self._bsub_binary
+        except AttributeError:
+            raise ValueError("LSF bsub binary location not set")
+
+    @bsub_binary.setter
+    def bsub_binary(self, value: str) -> None:
+        """ Set the LSF bsub binary location """
+        self._bsub_binary = value
+
+    @property
+    def num_cpus(self) -> int:
+        """ Get the LSF queue to use """
+        try:
+            return self._num_cpus
+        except AttributeError:
+            raise ValueError("Did not set the number of CPUs to use")
+
+    @num_cpus.setter
+    def num_cpus(self, value: int) -> None:
+        """ Set the LSF queue to use """
+        self._num_cpus = value # type: int
+
+    @property
+    def queue(self) -> Optional[str]:
+        """ Get the LSF queue to use """
+        try:
+            return self._queue
+        except AttributeError:
+            return None # use the default queue
+
+    @queue.setter
+    def queue(self, value: str) -> None:
+        """ Set the LSF queue to use """
+        self._queue = value # type: str
+
+    @property
+    def extra_args(self) -> List[str]:
+        """ Get the extra LSF args to use """
+        try:
+            return self._extra_args
+        except AttributeError:
+            # Use no extra args if empty
+            return [] # type : List[str]
+
+    @extra_args.setter
+    def extra_args(self, value: List[str]) -> None:
+        """ Set the extra LSF args to use """
+        self._extra_args = value
+
+    def bsub_args(self) -> List[str]:
+        args = [self.bsub_binary, "-K", "-n", "%d" % self.num_cpus] # always use -K to block
+        args.extend(self.extra_args)
+        if self.queue is not None:
+            args.extend(["-q", self.queue])
+        # TODO add more options as APIs (num_cpus, etc)
+        return args
+
+    def submit(self, args: List[str], env: Dict[str,str], logger: HammerVLSILoggingContext, cwd: str = None) -> str:
+        # TODO how to grab stdout/stderr from the LSF process without using temporary files?
+        logger.debug("Executing subprocess: " + ' '.join(self.bsub_args()) + '"' + ' '.join(args) + '"')
+        proc = subprocess.Popen(self.bsub_args() + [' '.join(args)], shell=False, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, env=env, cwd=cwd)
+        atexit.register(proc.kill)
+
+        return ""

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -26,7 +26,7 @@ from .hooks import HammerToolHookAction, HammerToolStep, HammerStepFunction, Hoo
 
 from .hammer_vlsi_impl import HierarchicalMode, LibraryFilter, HammerToolPauseException
 from .units import TimeValue, VoltageValue, TemperatureValue
-from .hammer_submit_command import HammerSubmitCommand
+from .submit_command import HammerSubmitCommand
 from hammer_utils import (add_lists, check_function_type, get_or_else, in_place_unique,
                           optional_map, reduce_named, reduce_list_str)
 

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -324,8 +324,7 @@ class HammerTool(metaclass=ABCMeta):
     @technology.setter
     def technology(self, value: hammer_tech.HammerTechnology) -> None:
         """Set the HammerTechnology currently in use."""
-        self._technology = value # type: hammer_tech.HammerTechnology
-
+        self._technology = value  # type: hammer_tech.HammerTechnology
 
     @property
     def submit_command(self) -> HammerSubmitCommand:
@@ -347,7 +346,6 @@ class HammerTool(metaclass=ABCMeta):
         :value: HammerSubmitCommand instance
         """
         self._submit_command = value
-
 
     @property
     def logger(self) -> HammerVLSILoggingContext:

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -26,7 +26,7 @@ from .hooks import HammerToolHookAction, HammerToolStep, HammerStepFunction, Hoo
 
 from .hammer_vlsi_impl import HierarchicalMode, LibraryFilter, HammerToolPauseException
 from .units import TimeValue, VoltageValue, TemperatureValue
-from .hammer_submit_command import HammerSubmitCommand, HammerBareSubmitCommand
+from .hammer_submit_command import HammerSubmitCommand
 from hammer_utils import (add_lists, check_function_type, get_or_else, in_place_unique,
                           optional_map, reduce_named, reduce_list_str)
 

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -337,8 +337,7 @@ class HammerTool(metaclass=ABCMeta):
         try:
             return self._submit_command
         except AttributeError:
-            # If this value isn't set, just return the bare submit command
-            return HammerBareSubmitCommand()
+            raise ValueError("Internal error: technology not set by hammer-vlsi")
 
     @submit_command.setter
     def submit_command(self, value: HammerSubmitCommand) -> None:

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -7,14 +7,12 @@
 #  Copyright 2018 Edward Wang <edward.c.wang@compdigitec.com>
 
 from abc import ABCMeta, abstractmethod
-import atexit
 from functools import reduce
 import inspect
 from numbers import Number
 import os
 import re
 import shlex
-import subprocess
 from typing import Callable, Iterable, List, Tuple, Optional, Dict, Any, Union, Set, cast, NamedTuple
 import warnings
 
@@ -28,6 +26,7 @@ from .hooks import HammerToolHookAction, HammerToolStep, HammerStepFunction, Hoo
 
 from .hammer_vlsi_impl import HierarchicalMode, LibraryFilter, HammerToolPauseException
 from .units import TimeValue, VoltageValue, TemperatureValue
+from .hammer_submit_command import HammerSubmitCommand, HammerBareSubmitCommand
 from hammer_utils import (add_lists, check_function_type, get_or_else, in_place_unique,
                           optional_map, reduce_named, reduce_list_str)
 
@@ -73,7 +72,6 @@ class ExtraLibrary(NamedTuple('ExtraLibrary', [
         lib_copied = hammer_tech.copy_library(self.library)  # type: hammer_tech.Library
         lib_copied.extra_prefixes = get_or_else(optional_map(self.prefix, lambda p: [p]), [])
         return lib_copied
-
 
 class HammerTool(metaclass=ABCMeta):
     # Interface methods.
@@ -327,6 +325,30 @@ class HammerTool(metaclass=ABCMeta):
     def technology(self, value: hammer_tech.HammerTechnology) -> None:
         """Set the HammerTechnology currently in use."""
         self._technology = value # type: hammer_tech.HammerTechnology
+
+
+    @property
+    def submit_command(self) -> HammerSubmitCommand:
+        """
+        Get the submit command used by this tool
+
+        :return HammerSubmitCommand instance
+        """
+        try:
+            return self._submit_command
+        except AttributeError:
+            # If this value isn't set, just return the bare submit command
+            return HammerBareSubmitCommand()
+
+    @submit_command.setter
+    def submit_command(self, value: HammerSubmitCommand) -> None:
+        """
+        Set the submit command used by this tool
+
+        :value: HammerSubmitCommand instance
+        """
+        self._submit_command = value
+
 
     @property
     def logger(self) -> HammerVLSILoggingContext:
@@ -947,35 +969,8 @@ class HammerTool(metaclass=ABCMeta):
         :param cwd: Working directory (leave as None to use the current working directory).
         :return: Output from the command or an error message.
         """
-        self.logger.debug("Executing subprocess: " + ' '.join(args))
 
-        # Short version for easier display in the log.
-        PROG_NAME_LEN = 14 # Capture last 14 characters of the command name
-        if len(args[0]) <= PROG_NAME_LEN:
-            prog_name = args[0]
-        else:
-            prog_name = "..." + args[0][len(args[0])-PROG_NAME_LEN:]
-        remaining_args = " ".join(args[1:])
-        if len(remaining_args) <= 15:
-            prog_args = remaining_args
-        else:
-            prog_args = remaining_args[0:15] + "..."
-        prog_tag = prog_name + " " + prog_args
-        subprocess_logger = self.logger.context("Exec " + prog_tag)
-
-        proc = subprocess.Popen(args, shell=False, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, env=self._subprocess_env, cwd=cwd)
-        atexit.register(proc.kill)
-        # Log output and also capture output at the same time.
-        output_buf = ""
-        while True:
-            line = proc.stdout.readline().decode("utf-8")
-            if line != '':
-                subprocess_logger.debug(line.rstrip())
-                output_buf += line
-            else:
-                break
-        # TODO: check errors
-        return line
+        return self.submit_command.submit(args, self._subprocess_env, self.logger, cwd)
 
     # Common convenient filters useful to many different tools.
     @staticmethod

--- a/src/hammer-vlsi/hammer_vlsi/submit_command.py
+++ b/src/hammer-vlsi/hammer_vlsi/submit_command.py
@@ -59,7 +59,7 @@ class HammerSubmitCommand:
         # Its value is a Dict[str, Any] comprising the settings for that command.
         # The top-level list elements are merged from 0 to the last index, with later indices overriding previous entries.
         def combine_settings(settings: List[Dict[str, Dict[str, Any]]], key: str) -> Dict[str, Any]:
-            return reduce(add_dicts, map(lambda d: d[key], settings))
+            return reduce(add_dicts, map(lambda d: d[key], settings), {})
 
         submit_command = None # type: Optional[HammerSubmitCommand]
         if submit_command_mode == "none" or submit_command_mode == "local":
@@ -125,6 +125,8 @@ class HammerLSFSettings(NamedTuple('HammerLSFSettings', [
 
     @staticmethod
     def from_setting(d: Dict[str, Any]) -> "HammerLSFSettings":
+        if not isinstance(d, dict):
+            raise ValueError("Must be a dictionary")
         try:
             bsub_binary = d["bsub_binary"]
         except KeyError:

--- a/src/hammer-vlsi/hammer_vlsi/submit_command.py
+++ b/src/hammer-vlsi/hammer_vlsi/submit_command.py
@@ -49,7 +49,9 @@ class HammerSubmitCommand:
         """
 
         submit_command_mode = database.get_setting(tool_namespace + ".submit.command", nullvalue="none")
-        submit_command_settings = database.get_setting(tool_namespace + ".submit.settings", nullvalue=[]) # type: List[Dict[str, Dict[str, Any]]]
+        # TODO This is sketchy
+        submit_command_settings = database.get_setting("vlsi.submit.settings", nullvalue=[]) + \
+            database.get_setting(tool_namespace + ".submit.settings", nullvalue=[]) # type: List[Dict[str, Dict[str, Any]]]
 
         # Settings is a List[Dict[str, Dict[str, Any]]] object. The first Dict key is the submit command name.
         # Its value is a Dict[str, Any] comprising the settings for that command.
@@ -173,7 +175,7 @@ class HammerLSFSubmitCommand(HammerSubmitCommand):
         try:
             self.bsub_binary = settings["bsub_binary"]
         except KeyError:
-            raise ValueError("Missing mandatory LSF setting bsub_binary for tool %s", tool_name)
+            raise ValueError("Missing mandatory LSF setting bsub_binary for tool %s" % tool_name)
         try:
             self.num_cpus = settings["num_cpus"] # type: Optional[int]
         except KeyError:

--- a/src/hammer-vlsi/hammer_vlsi/submit_command.py
+++ b/src/hammer-vlsi/hammer_vlsi/submit_command.py
@@ -13,6 +13,8 @@ from hammer_logging import HammerVLSIFileLogger, HammerVLSILogging, HammerVLSILo
 from hammer_config import HammerDatabase
 from functools import reduce
 
+__all__ = ['HammerSubmitCommand', 'HammerLocalSubmitCommand', 'HammerLSFSettings', 'HammerLSFSubmitCommand']
+
 class HammerSubmitCommand:
 
     @abstractmethod

--- a/src/hammer-vlsi/test.py
+++ b/src/hammer-vlsi/test.py
@@ -1051,18 +1051,19 @@ class HammerToolHooksTest(unittest.TestCase):
                 else:
                     self.assertFalse(os.path.exists(file))
 
+
 class HammerSubmitCommandTestContext:
 
     def __init__(self, test: unittest.TestCase, cmd_type: str) -> None:
         self.echo_command_args = ["go", "bears", "!"]
         self.echo_command = ["echo"] + self.echo_command_args
-        self.test = test # type unittest.TestCase
+        self.test = test  # type unittest.TestCase
         self.logger = HammerVLSILogging.context("")
-        self._driver = None # type: Optional[hammer_vlsi.HammerDriver]
+        self._driver = None  # type: Optional[hammer_vlsi.HammerDriver]
         if cmd_type not in ["lsf", "local"]:
             raise NotImplementedError("Have not built a test for %s yet" % cmd_type)
         self._cmd_type = cmd_type
-        self._submit_command = None # type: Optional[hammer_vlsi.HammerSubmitCommand]
+        self._submit_command = None  # type: Optional[hammer_vlsi.HammerSubmitCommand]
 
     # Helper property to check that the driver did get initialized.
     @property
@@ -1079,7 +1080,7 @@ class HammerSubmitCommandTestContext:
     def __enter__(self) -> "HammerSubmitCommandTestContext":
         """Initialize context by creating the temp_dir, driver, and loading mocksynth."""
         self.test.assertTrue(hammer_vlsi.HammerVLSISettings.set_hammer_vlsi_path_from_environment(),
-                        "hammer_vlsi_path must exist")
+                             "hammer_vlsi_path must exist")
         temp_dir = tempfile.mkdtemp()
         json_path = os.path.join(temp_dir, "project.json")
         json_content = {
@@ -1095,7 +1096,8 @@ class HammerSubmitCommandTestContext:
                 "synthesis.submit.settings": [{"lsf": {
                     "queue": "myqueue",
                     "num_cpus": 4,
-                    "bsub_binary": os.path.join(os.path.dirname(os.path.abspath(__file__)),"..","test","mock_bsub.sh"),
+                    "bsub_binary": os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "test",
+                                                "mock_bsub.sh"),
                     "extra_args": ("-R", "myresources")
                 }}]
             })
@@ -1125,7 +1127,7 @@ class HammerSubmitCommandTestContext:
         return self.driver.database
 
     @property
-    def env(self) -> Dict[str,str]:
+    def env(self) -> Dict[str, str]:
         return {}
 
 
@@ -1140,8 +1142,7 @@ class HammerSubmitCommandTest(unittest.TestCase):
             cmd = c.submit_command
             output = cmd.submit(c.echo_command, c.env, c.logger).splitlines()
 
-            self.assertEqual(output[0],' '.join(c.echo_command_args))
-
+            self.assertEqual(output[0], ' '.join(c.echo_command_args))
 
     def test_lsf_submit(self) -> None:
         """ Test that an LSF submission produces the desired output """
@@ -1150,20 +1151,20 @@ class HammerSubmitCommandTest(unittest.TestCase):
             assert isinstance(cmd, hammer_vlsi.HammerLSFSubmitCommand)
             output = cmd.submit(c.echo_command, c.env, c.logger).splitlines()
 
-            self.assertEqual(output[0],"BLOCKING is: 1")
-            self.assertEqual(output[1],"QUEUE is: %s" % get_or_else(cmd.settings.queue, ""))
-            self.assertEqual(output[2],"NUMCPU is: %d" % get_or_else(cmd.settings.num_cpus, 0))
+            self.assertEqual(output[0], "BLOCKING is: 1")
+            self.assertEqual(output[1], "QUEUE is: %s" % get_or_else(cmd.settings.queue, ""))
+            self.assertEqual(output[2], "NUMCPU is: %d" % get_or_else(cmd.settings.num_cpus, 0))
 
             extra = cmd.settings.extra_args
             has_resource = 0
             if "-R" in extra:
                 has_resource = 1
-                self.assertEqual(output[3],"RESOURCE is: %s" % extra[extra.index("-R") + 1])
+                self.assertEqual(output[3], "RESOURCE is: %s" % extra[extra.index("-R") + 1])
             else:
                 raise NotImplementedError("You forgot to test the extra_args!")
 
-            self.assertEqual(output[3 + has_resource],"COMMAND is: %s" % ' '.join(c.echo_command))
-            self.assertEqual(output[4 + has_resource],' '.join(c.echo_command_args))
+            self.assertEqual(output[3 + has_resource], "COMMAND is: %s" % ' '.join(c.echo_command))
+            self.assertEqual(output[4 + has_resource], ' '.join(c.echo_command_args))
 
 
 if __name__ == '__main__':

--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -316,7 +316,7 @@ class HammerDatabase:
         """Alias for has_setting()."""
         return self.has_setting(item)
 
-    def get_setting(self, key: str, nullvalue: str = "null") -> Any:
+    def get_setting(self, key: str, nullvalue: Any = "null") -> Any:
         """
         Retrieve the given key.
 

--- a/src/test/mock_bsub.sh
+++ b/src/test/mock_bsub.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Option parser from https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
 
 POSITIONAL=()

--- a/src/test/mock_bsub.sh
+++ b/src/test/mock_bsub.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Option parser from https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+key="$1"
+case $key in
+    -q)
+    QUEUE="$2"
+    shift
+    shift
+    ;;
+    -n)
+    NUMCPU="$2"
+    shift
+    shift
+    ;;
+    -R)
+    RESOURCE="$2"
+    shift
+    shift
+    ;;
+    -K)
+    BLOCKING=1
+    shift
+    ;;
+    *)
+    POSITIONAL+=("$1")
+    shift
+    ;;
+esac
+done
+
+if [ ! -z "$BLOCKING" ]; then echo "BLOCKING is: $BLOCKING"; fi
+if [ ! -z "$QUEUE" ]; then echo "QUEUE is: $QUEUE"; fi
+if [ ! -z "$NUMCPU" ]; then echo "NUMCPU is: $NUMCPU"; fi
+if [ ! -z "$RESOURCE" ]; then echo "RESOURCE is: $RESOURCE"; fi
+echo "COMMAND is: ${POSITIONAL[@]}"
+exec ${POSITIONAL[@]}


### PR DESCRIPTION
This PR moves most of the guts of HammerTool.run_executable into a new class HammerBareSubmitCommand, a subclass of a new abstract HammerSubmitCommand (not sold on this name) that would allow us to implement LSF, qsub, etc. An example LSF command is included but it needs some features.