### PR TITLE
Refactor hammer_config

### DIFF
--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -12,7 +12,7 @@
 from typing import Iterable, List, Union, Callable, Any, Dict, Set
 
 from hammer_utils import deepdict
-from .yaml2json import load_yaml # grumble grumble
+from .yaml2json import load_yaml  # grumble grumble
 
 from functools import reduce
 import json

--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -223,7 +223,8 @@ def get_meta_directives() -> Dict[str, MetaDirective]:
 
     def transclude_rename(key: str, value: Any, target_setting: str, replacement_setting: str) -> Optional[
         Tuple[Any, str]]:
-        raise NotImplementedError()
+        # This meta directive doesn't depend on any settings
+        return value, "transclude"
 
     # transclude depends on external files, not other settings.
     directives['transclude'] = MetaDirective(action=transclude_action,
@@ -239,7 +240,8 @@ def get_meta_directives() -> Dict[str, MetaDirective]:
 
     def json2list_rename(key: str, value: Any, target_setting: str, replacement_setting: str) -> Optional[
         Tuple[Any, str]]:
-        raise NotImplementedError()
+        # This meta directive doesn't depend on any settings
+        return value, "json2list"
 
     # json2list does not depend on anything
     directives['json2list'] = MetaDirective(action=json2list_action,
@@ -252,7 +254,8 @@ def get_meta_directives() -> Dict[str, MetaDirective]:
 
     def prependlocal_rename(key: str, value: Any, target_setting: str, replacement_setting: str) -> Optional[
         Tuple[Any, str]]:
-        raise NotImplementedError()
+        # This meta directive doesn't depend on any settings
+        return value, "prependlocal"
 
     # prependlocal does not depend on anything in config_dict.
     directives['prependlocal'] = MetaDirective(action=prependlocal_action,

--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -183,6 +183,22 @@ def update_and_expand_meta(config_dict: dict, meta_dict: dict) -> dict:
         def meta_dynamic(config_dict: dict, key: str, value: Any) -> None:
             # Do nothing at this stage, since we need to deal with dynamicsubst only after
             # everything has been bound.
+
+            # If overriding a variable that already has a dynamic meta,
+            # error out since this isn't supported yet.
+            if key in config_dict:
+                if (key + "_meta") in config_dict:
+                    prev_meta_raw = config_dict[key + "_meta"]
+                    prev_meta = ""  # type: str
+                    if isinstance(prev_meta, list):
+                        prev_meta = str(prev_meta_raw[0])
+                    else:
+                        prev_meta = str(prev_meta_raw)
+
+                    if prev_meta.startswith("dynamic"):
+                        raise ValueError(
+                            "Overriding a dynamic meta with another dynamic meta is not currently supported")
+
             config_dict[key] = value
             config_dict[key + "_meta"] = dynamic_meta
 

--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -296,13 +296,20 @@ def update_and_expand_meta(config_dict: dict, meta_dict: dict) -> dict:
             # If it's a dynamic meta, skip it for now since they are lazily
             # processed at the very end.
             if meta_type.startswith("dynamic"):
-                if meta_type[len("dynamic"):] not in get_meta_directives():
+                dynamic_base_meta_type = meta_type[len("dynamic"):]
+
+                if dynamic_base_meta_type not in get_meta_directives():
                     raise ValueError("The type of dynamic meta variable %s is not supported (%s)" % (meta_key, meta_type))
 
                 if seen_dynamic:
                     raise ValueError("Multiple dynamic directives in a single directive array not supported yet")
                 else:
                     seen_dynamic = True
+
+                # Check if this dynamic meta references itself.
+                for target_setting in get_meta_directives()[dynamic_base_meta_type].target_settings(setting, meta_dict[setting]):
+                    if setting == target_setting:
+                        raise NotImplementedError()
 
                 # Store it into newdict and skip processing now.
                 newdict[setting] = meta_dict[setting]

--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-#  Copyright 2017 Edward Wang <edward.c.wang@compdigitec.com>
+#  Copyright 2017-2018 Edward Wang <edward.c.wang@compdigitec.com>
 #
 #  Build the configuration database from a series of JSON config files.
 #  Dumps the output in JSON format to standard output.
@@ -22,7 +22,7 @@ import re
 import sys
 
 # Special key used for meta directives which require config paths like prependlocal.
-CONFIG_PATH_KEY = "_config_path"
+_CONFIG_PATH_KEY = "_config_path"
 
 
 def unpack(config_dict: dict, prefix: str = "") -> dict:
@@ -191,7 +191,7 @@ def update_and_expand_meta(config_dict: dict, meta_dict: dict) -> dict:
 
     def meta_prependlocal(config_dict: dict, key: str, value) -> None:
         """Prepend the local path of the config dict."""
-        config_dict[key] = os.path.join(meta_dict[CONFIG_PATH_KEY], str(value))
+        config_dict[key] = os.path.join(meta_dict[_CONFIG_PATH_KEY], str(value))
 
     # Lookup table of meta functions.
     meta_directive_functions = {
@@ -286,7 +286,7 @@ class HammerDatabase:
     @staticmethod
     def internal_keys() -> Set[str]:
         """Internal keys that shouldn't show up in any final config."""
-        return {CONFIG_PATH_KEY}
+        return {_CONFIG_PATH_KEY}
 
     def get_config(self) -> dict:
         """
@@ -402,7 +402,7 @@ def load_config_from_string(contents: str, is_yaml: bool, path: str = "unspecifi
     :return: Loaded config dictionary, unpacked.
     """
     unpacked = unpack(load_yaml(contents) if is_yaml else json.loads(contents))
-    unpacked[CONFIG_PATH_KEY] = path
+    unpacked[_CONFIG_PATH_KEY] = path
     return unpacked
 
 
@@ -487,8 +487,8 @@ def combine_configs(configs: Iterable[dict]) -> dict:
     final_dict = update_and_expand_meta(expanded_config, dynamic_metas)
 
     # Remove the temporary key used for path metas.
-    if CONFIG_PATH_KEY in final_dict:
-        del final_dict[CONFIG_PATH_KEY]
+    if _CONFIG_PATH_KEY in final_dict:
+        del final_dict[_CONFIG_PATH_KEY]
 
     return final_dict
 

--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -23,6 +23,25 @@ import re
 # Special key used for meta directives which require config paths like prependlocal.
 _CONFIG_PATH_KEY = "_config_path"
 
+# Special key used to keep track of the next available integer suffix to avoid
+# duplicate keys.
+_NEXT_FREE_INDEX_KEY = "_next_free_index"
+
+
+def _get_next_free_index(d: dict) -> int:
+    """
+    Get the next free index in the given dictionary.
+    Side effect: increments the next free index stored in the dictionary by 1.
+    If the key does not exist, create it and set it to 2, and return 1.
+    :param d: Dictionary to find the next free index in.
+    :return: Next free index.
+    """
+    if _NEXT_FREE_INDEX_KEY not in d:
+        d[_NEXT_FREE_INDEX_KEY] = 1
+    next_index = int(d[_NEXT_FREE_INDEX_KEY])
+    d[_NEXT_FREE_INDEX_KEY] = next_index + 1
+    return next_index
+
 
 # Miscellaneous parameters involved in executing a meta directive.
 class MetaDirectiveParams(NamedTuple('MetaDirectiveParams', [
@@ -375,7 +394,7 @@ class HammerDatabase:
     @staticmethod
     def internal_keys() -> Set[str]:
         """Internal keys that shouldn't show up in any final config."""
-        return {_CONFIG_PATH_KEY}
+        return {_CONFIG_PATH_KEY, _NEXT_FREE_INDEX_KEY}
 
     def get_config(self) -> dict:
         """

--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -19,7 +19,6 @@ import json
 import numbers
 import os
 import re
-import sys
 
 # Special key used for meta directives which require config paths like prependlocal.
 _CONFIG_PATH_KEY = "_config_path"

--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -194,7 +194,21 @@ def get_meta_directives() -> Dict[str, MetaDirective]:
 
     def crossref_rename(key: str, value: Any, target_setting: str, replacement_setting: str) -> Optional[
         Tuple[Any, str]]:
-        raise NotImplementedError()
+        def change_if_target(x: str) -> str:
+            if x == target_setting:
+                return replacement_setting
+            else:
+                return x
+
+        if type(value) == str:
+            return [change_if_target(value)], "crossref"
+        elif type(value) == list:
+            return list(map(change_if_target, map(crossref_check_and_cast, value))), "crossref"
+        elif isinstance(value, numbers.Number):
+            # bools are instances of numbers.Number for some weird reason
+            raise ValueError("crossref cannot be used with numbers and bools")
+        else:
+            raise NotImplementedError("crossref not implemented on other types yet")
 
     directives['crossref'] = MetaDirective(action=crossref_action,
                                            target_settings=crossref_targets,

--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -485,9 +485,10 @@ def combine_configs(configs: Iterable[dict]) -> dict:
 
     final_dict = update_and_expand_meta(expanded_config, dynamic_metas)
 
-    # Remove the temporary key used for path metas.
-    if _CONFIG_PATH_KEY in final_dict:
-        del final_dict[_CONFIG_PATH_KEY]
+    # Remove any temporary keys.
+    for key in HammerDatabase.internal_keys():
+        if key in final_dict:
+            del final_dict[key]
 
     return final_dict
 

--- a/src/hammer_config_test/test.py
+++ b/src/hammer_config_test/test.py
@@ -514,7 +514,7 @@ test_meta: ["dynamicsubst", "dynamiccrossref"]
             self.assertEqual(db.get_setting("base"), "hello2")
             self.assertEqual(db.get_setting("test"), "def")
         msg = cm.exception.args[0]
-        self.assertTrue("Overriding a dynamic meta with another dynamic meta is not currently supported" in msg)
+        self.assertTrue("Multiple dynamic directives in a single directive array not supported yet" in msg)
 
     def test_meta_append_bad(self):
         """
@@ -552,6 +552,7 @@ foo:
         Test that load_yaml works with empty dictionaries.
         """
         self.assertEqual(hammer_config.load_yaml("x: {}"), {"x": {}})
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/hammer_config_test/test.py
+++ b/src/hammer_config_test/test.py
@@ -154,7 +154,7 @@ style: "waterfall"
         self.assertEqual(db.get_setting("foo.later"), "later")
         self.assertEqual(db.get_setting("foo.methodology"), "agile design")
 
-    def test_meta_append(self):
+    def test_meta_append(self) -> None:
         """
         Test that the meta attribute "append" works.
         """

--- a/src/hammer_config_test/test.py
+++ b/src/hammer_config_test/test.py
@@ -243,6 +243,31 @@ foo:
         self.assertEqual(db.get_setting("foo.twelve"), "whatever")
         self.assertEqual(db.get_setting("later"), "whatever")
 
+    def test_meta_repeated_dynamic(self) -> None:
+        """
+        Test that repeated applications of a dynamic command work.
+        """
+        db = hammer_config.HammerDatabase()
+        base = hammer_config.load_config_from_string("""
+base_str: "hello"
+derivative_str: "${base_str}"
+derivative_str_meta: "dynamicsubst"
+        """, is_yaml=True)
+        config1 = hammer_config.load_config_from_string("""
+{
+    "derivative_str": "${derivative_str}_1",
+    "derivative_str_meta": "dynamicsubst"
+}
+        """, is_yaml=True)
+        config2 = hammer_config.load_config_from_string("""
+{
+    "derivative_str": "${derivative_str}_2",
+    "derivative_str_meta": "dynamicsubst"
+}
+        """, is_yaml=True)
+        db.update_core([base, config1, config2])
+        self.assertEqual(db.get_setting("derivative_str"), "hello_1_2")
+
     def test_repeated_updates(self) -> None:
         """
         Test that repeated updates don't cause duplicates.

--- a/src/hammer_config_test/test.py
+++ b/src/hammer_config_test/test.py
@@ -154,35 +154,6 @@ style: "waterfall"
         self.assertEqual(db.get_setting("foo.later"), "later")
         self.assertEqual(db.get_setting("foo.methodology"), "agile design")
 
-    def test_meta_dynamicsubst_other_dynamicsubst(self):
-        """
-        Check that a dynamicsubst which references other dynamicsubst errors for now.
-        """
-        """
-        Test that the meta attribute "dynamicsubst" works.
-        """
-        db = hammer_config.HammerDatabase()
-        base = hammer_config.load_config_from_string("""
-foo:
-    flash: "yes"
-    one: "1"
-    two: "2"
-    lolcat: ""
-    twelve: "${lolcat}"
-    twelve_meta: dynamicsubst
-""", is_yaml=True)
-        project = hammer_config.load_config_from_string("""
-{
-  "lolcat": "whatever",
-  "later": "${foo.twelve}",
-  "later_meta": "dynamicsubst"
-}
-""", is_yaml=False)
-        db.update_core([base])
-        db.update_project([project])
-        with self.assertRaises(ValueError):
-            print(db.get_config())
-
     def test_meta_append(self):
         """
         Test that the meta attribute "append" works.
@@ -205,6 +176,72 @@ foo:
         db.update_core([base, meta])
         self.assertEqual(db.get_setting("foo.bar.dac"), "current_weighted")
         self.assertEqual(db.get_setting("foo.bar.dsl"), ["scala", "python"])
+
+    def test_meta_dynamic_referencing_other_dynamic(self) -> None:
+        """
+        Test that dynamic settings can reference other dynamic settings.
+        """
+        db = hammer_config.HammerDatabase()
+        base = hammer_config.load_config_from_string("""
+global: "hello world"
+tool1:
+    common: "${global} tool1"
+    common_meta: "dynamicsubst"
+    a: "${tool1.common} abc"
+    a_meta: "dynamicsubst"
+    b: "${tool1.common} bcd"
+    b_meta: "dynamicsubst"
+tool2:
+    common: "${global} tool2"
+    common_meta: "dynamicsubst"
+    x: "${tool2.common} xyz"
+    x_meta: "dynamicsubst"
+    z: "${tool2.common} zyx"
+    z_meta: "dynamicsubst"
+conglomerate: "${tool1.common} + ${tool2.common}"
+conglomerate_meta: "dynamicsubst"
+""", is_yaml=True)
+        meta = hammer_config.load_config_from_string("""
+{
+  "global": "foobar"
+}
+""", is_yaml=False)
+        db.update_core([base, meta])
+        self.assertEqual(db.get_setting("global"), "foobar")
+        self.assertEqual(db.get_setting("tool1.common"), "foobar tool1")
+        self.assertEqual(db.get_setting("tool1.a"), "foobar tool1 abc")
+        self.assertEqual(db.get_setting("tool1.b"), "foobar tool1 bcd")
+        self.assertEqual(db.get_setting("tool2.common"), "foobar tool2")
+        self.assertEqual(db.get_setting("tool2.x"), "foobar tool2 xyz")
+        self.assertEqual(db.get_setting("tool2.z"), "foobar tool2 zyx")
+        self.assertEqual(db.get_setting("conglomerate"), "foobar tool1 + foobar tool2")
+
+    def test_meta_dynamicsubst_other_dynamicsubst(self) -> None:
+        """
+        Check that a dynamicsubst which references other dynamicsubst works.
+        """
+        db = hammer_config.HammerDatabase()
+        base = hammer_config.load_config_from_string("""
+foo:
+    flash: "yes"
+    one: "1"
+    two: "2"
+    lolcat: ""
+    twelve: "${lolcat}"
+    twelve_meta: dynamicsubst
+    """, is_yaml=True)
+        project = hammer_config.load_config_from_string("""
+{
+  "lolcat": "whatever",
+  "later": "${foo.twelve}",
+  "later_meta": "dynamicsubst"
+}
+    """, is_yaml=False)
+        db.update_core([base])
+        db.update_project([project])
+        self.assertEqual(db.get_setting("lolcat"), "whatever")
+        self.assertEqual(db.get_setting("foo.twelve"), "whatever")
+        self.assertEqual(db.get_setting("later"), "whatever")
 
     def test_repeated_updates(self) -> None:
         """

--- a/src/hammer_config_test/test.py
+++ b/src/hammer_config_test/test.py
@@ -14,7 +14,7 @@ import hammer_config
 
 class HammerDatabaseTest(unittest.TestCase):
 
-    def test_overriding(self):
+    def test_overriding(self) -> None:
         """
         Test that we can add a project first and technology after and still have it override.
         """
@@ -24,7 +24,7 @@ class HammerDatabaseTest(unittest.TestCase):
         db.update_technology([{"tech.x": "bar"}])
         self.assertEqual(db.get_setting("tech.x"), "foo")
 
-    def test_unpacking(self):
+    def test_unpacking(self) -> None:
         """
         Test that input configs get unpacked.
         """
@@ -39,7 +39,7 @@ foo:
         self.assertEqual(db.get_setting("foo.bar.adc"), "yes")
         self.assertEqual(db.get_setting("foo.bar.dac"), "no")
 
-    def test_no_config_junk(self):
+    def test_no_config_junk(self) -> None:
         """Test that no _config_path junk variables get left behind."""
         db = hammer_config.HammerDatabase()
         db.update_core([hammer_config.load_config_from_string("key1: value1", is_yaml=True)])
@@ -70,7 +70,7 @@ a.b.c_meta: append
         db.update_environment([])
         self.assertEqual(db.get_setting("a.b.c"), ["test"])
 
-    def test_meta_json2list(self):
+    def test_meta_json2list(self) -> None:
         """
         Test that the meta attribute "json2list" works.
         """
@@ -91,7 +91,7 @@ foo:
         self.assertEqual(db.get_setting("foo.max"), "min")
         self.assertEqual(db.get_setting("foo.pipeline"), ["1", "2"])
 
-    def test_meta_dynamicjson2list(self):
+    def test_meta_dynamicjson2list(self) -> None:
         """
         Test that the meta attribute "dynamicjson2list" works.
         """
@@ -113,7 +113,7 @@ foo:
         self.assertEqual(db.get_setting("foo.max"), "min")
         self.assertEqual(db.get_setting("foo.pipeline"), ["1", "2"])
 
-    def test_meta_subst(self):
+    def test_meta_subst(self) -> None:
         """
         Test that the meta attribute "subst" works.
         """
@@ -137,7 +137,7 @@ foo:
         self.assertEqual(db.get_setting("foo.pipeline"), "yesman")
         self.assertEqual(db.get_setting("foo.uint"), ["1", "2"])
 
-    def test_meta_dynamicsubst(self):
+    def test_meta_dynamicsubst(self) -> None:
         """
         Test that the meta attribute "dynamicsubst" works.
         """
@@ -307,7 +307,7 @@ my:
             db.update_core([base, meta])
             db.get_setting("bad_list")
 
-    def test_meta_prependlocal(self):
+    def test_meta_prependlocal(self) -> None:
         """
         Test that the meta attribute "prependlocal" works.
         """
@@ -336,7 +336,7 @@ foo:
         self.assertEqual(db.get_setting("foo.bar.base_test"), "base/config/path/local_path")
         self.assertEqual(db.get_setting("foo.bar.meta_test"), "meta/config/path/local_path")
 
-    def test_meta_transclude(self):
+    def test_meta_transclude(self) -> None:
         """
         Test that the meta attribute "transclude" works.
         """
@@ -370,7 +370,7 @@ chips:
         self.assertEqual(db.get_setting("chips.bear"), "yeah")
         self.assertEqual(db.get_setting("chips.tree"), file_contents)
 
-    def test_meta_transclude_prependlocal(self):
+    def test_meta_transclude_prependlocal(self) -> None:
         """
         Test that the meta attribute "transclude" works with "prependlocal".
         """
@@ -405,7 +405,7 @@ chips:
         self.assertEqual(db.get_setting("chips.bear"), "yeah")
         self.assertEqual(db.get_setting("chips.tree"), os.path.join(local_path, file_contents))
 
-    def test_meta_transclude_subst(self):
+    def test_meta_transclude_subst(self) -> None:
         """
         Test that the meta attribute "transclude" works with "subst".
         """
@@ -440,7 +440,7 @@ food:
 
         self.assertEqual(db.get_setting("food.announcement"), file_contents_sol)
 
-    def test_meta_as_array_1(self):
+    def test_meta_as_array_1(self) -> None:
         """
         Test meta attributes that are an array.
         """
@@ -460,7 +460,7 @@ foo:
         self.assertEqual(db.get_setting("foo.bar.base_test"), "local_path")
         self.assertEqual(db.get_setting("foo.bar.meta_test"), "local_path")
 
-    def test_meta_subst_and_prependlocal(self):
+    def test_meta_subst_and_prependlocal(self) -> None:
         """
         Test meta attributes that are an array.
         """

--- a/src/hammer_config_test/test.py
+++ b/src/hammer_config_test/test.py
@@ -505,7 +505,7 @@ test_meta: ["dynamicsubst", "dynamiccrossref"]
         msg = cm.exception.args[0]
         self.assertTrue("Multiple dynamic directives in a single directive array not supported yet" in msg)
 
-    def test_meta_append_bad(self):
+    def test_meta_append_bad(self) -> None:
         """
         Test that the meta attribute "append" catches bad inputs.
         """
@@ -607,6 +607,44 @@ foo:
         self.assertEqual(db.get_setting("lolcat"), "whatever")
         self.assertEqual(db.get_setting("foo.twelve"), "whatever")
         self.assertEqual(db.get_setting("later"), "whatever")
+
+    def test_meta_dynamiccrossappend_with_dynamiccrossref(self) -> None:
+        """
+        Test that dynamic crossappend works with dynamic crossref in one file.
+        """
+        db = hammer_config.HammerDatabase()
+        base = hammer_config.load_config_from_string("""
+global: ["hello", "world", "scala"]
+tool_1: "global"
+tool_1_meta: "dynamiccrossref"
+tool: ["tool_1", ["python"]]
+tool_meta: "dynamiccrossappend"
+""", is_yaml=True)
+        db.update_core([base])
+        self.assertEqual(db.get_setting("global"), ["hello", "world", "scala"])
+        self.assertEqual(db.get_setting("tool"), ["hello", "world", "scala", "python"])
+
+    def test_meta_dynamicappend_with_dynamiccrossref_2(self) -> None:
+        """
+        Test that dynamic "append" works with dynamic crossref.
+        """
+        db = hammer_config.HammerDatabase()
+        base = hammer_config.load_config_from_string("""
+global: ["hello", "world"]
+tool: "global"
+tool_meta: "dynamiccrossref"
+""", is_yaml=True)
+        meta = hammer_config.load_config_from_string("""
+{
+  "global": ["scala"],
+  "global_meta": "append",
+  "tool": ["python"],
+  "tool_meta": "dynamicappend"
+}
+""", is_yaml=False)
+        db.update_core([base, meta])
+        self.assertEqual(db.get_setting("global"), ["hello", "world", "scala"])
+        self.assertEqual(db.get_setting("tool"), ["hello", "world", "scala", "python"])
 
     def test_self_reference_dynamicsubst(self) -> None:
         """

--- a/src/hammer_config_test/test.py
+++ b/src/hammer_config_test/test.py
@@ -590,9 +590,9 @@ foo:
         self.assertEqual(db.get_setting("foo.twelve"), "whatever")
         self.assertEqual(db.get_setting("later"), "whatever")
 
-    def test_meta_repeated_dynamic(self) -> None:
+    def test_self_reference_dynamicsubst(self) -> None:
         """
-        Test that repeated applications of a dynamic command work.
+        Test that self-referencing dynamic subst works.
         """
         db = hammer_config.HammerDatabase()
         base = hammer_config.load_config_from_string("""
@@ -614,6 +614,32 @@ derivative_str_meta: "dynamicsubst"
         """, is_yaml=True)
         db.update_core([base, config1, config2])
         self.assertEqual(db.get_setting("derivative_str"), "hello_1_2")
+
+    def test_self_reference_dynamiccrossref(self) -> None:
+        """
+        Test that self-referencing dynamic crossref works.
+        """
+        db = hammer_config.HammerDatabase()
+        base = hammer_config.load_config_from_string("""
+base: "hello"
+derivative: "base"
+derivative_meta: "dynamiccrossref"
+        """, is_yaml=True)
+        config1 = hammer_config.load_config_from_string("""
+{
+    "derivative": "derivative",
+    "derivative_meta": "dynamiccrossref"
+}
+        """, is_yaml=True)
+        config2 = hammer_config.load_config_from_string("""
+{
+    "base": "tower",
+    "derivative": "derivative",
+    "derivative_meta": "dynamiccrossref"
+}
+        """, is_yaml=True)
+        db.update_core([base, config1, config2])
+        self.assertEqual(db.get_setting("base"), "tower")
 
 
 if __name__ == '__main__':

--- a/src/hammer_config_test/test.py
+++ b/src/hammer_config_test/test.py
@@ -454,7 +454,7 @@ food:
 
     def test_meta_as_array_1(self):
         """
-        Test that meta attributes that are an array.
+        Test meta attributes that are an array.
         """
         db = hammer_config.HammerDatabase()
         base = hammer_config.load_config_from_string("""
@@ -474,7 +474,7 @@ foo:
 
     def test_meta_subst_and_prependlocal(self):
         """
-        Test that meta attributes that are an array.
+        Test meta attributes that are an array.
         """
         db = hammer_config.HammerDatabase()
         base = hammer_config.load_config_from_string("""


### PR DESCRIPTION
Main highlights: enable a setting with dynamic meta directives to reference another setting with dynamic meta directives. Enables dynamic meta directives to reference themselves (enables things like dynamicappend, etc). General refactors to make dealing with meta directives more DRY.

Paves the way to fixing #230.

This PR should be fully backwards-compatible (only introduces new support, doesn't remove any features).