### PR TITLE
Auto generate properties

### DIFF
--- a/src/hammer-vlsi/generate_properties.py
+++ b/src/hammer-vlsi/generate_properties.py
@@ -186,9 +186,10 @@ def main(args) -> int:
 
     if selected_file == "":
         # Export all files
+        # print without extra newline
         for filename, contents in file_cache.items():
             if dry_run:
-                print(contents)
+                print(contents, end='')
             else:
                 with open(filename, "w") as f:
                     f.write(contents)
@@ -196,7 +197,7 @@ def main(args) -> int:
         # Export selected file
         contents = file_cache[get_full_filename(selected_file)]
         if dry_run:
-            print(contents)
+            print(contents, end='')
         else:
             with open(filename, "w") as f:
                 f.write(contents)

--- a/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py
@@ -569,6 +569,7 @@ class HammerDRCTool(HammerSignoffTool):
             raise TypeError("layout_file must be a str")
         self.attr_setter("_layout_file", value)
 
+
     @property
     def top_module(self) -> str:
         """

--- a/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py
@@ -1203,4 +1203,3 @@ def load_tool(tool_name: str, path: Iterable[str]) -> HammerTool:
     tool = tool_class()
     tool.tool_dir = os.path.dirname(os.path.abspath(mod.__file__))
     return tool
-

--- a/src/test/check_generate_properties.sh
+++ b/src/test/check_generate_properties.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+trap "rm -f _tmp_vlsi.txt" EXIT
+
+../hammer-vlsi/generate_properties.py -d -f hammer_vlsi/hammer_vlsi_impl.py > _tmp_vlsi.txt
+
+if cmp --silent "../hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py" "_tmp_vlsi.txt"; then
+    # Files have the same content
+    exit 0
+else
+    echo "generate_properties.py is inconsistent with the generated files"
+    diff -u "../hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py" "_tmp_vlsi.txt"
+    exit 1
+fi


### PR DESCRIPTION
Closes #237 

This is reliant on #213. Running `./generate_properties.py` now directly edits `hammer_vlsi_impl.py`.