### PR TITLE
supply filter assumes mmmc runs need all libraries

### DIFF
--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -643,9 +643,10 @@ class HammerTechnology:
             # always be used.
             self.logger.warning("Lib %s has no supplies annotation! Using anyway." % (lib.serialize()))
             return True
-        # If we are using MMMC assume all libraries will be used
-        # TODO: Read the corners and filter out libraries that don't match any of them
-        #  Requires a refactor because MMMCCorner parsing is only in HammerTool now
+        # If we are using MMMC assume all libraries will be used.
+        # TODO: Read the corners and filter out libraries that don't match any of them.
+        # Requires a refactor because MMMCCorner parsing is only in HammerTool now.
+        # See issue #275.
         if self.get_setting("vlsi.inputs.mmmc_corners"):
             return True
         return self.get_setting("vlsi.inputs.supplies.VDD") == lib.supplies.VDD and self.get_setting("vlsi.inputs.supplies.GND") == lib.supplies.GND

--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -643,6 +643,11 @@ class HammerTechnology:
             # always be used.
             self.logger.warning("Lib %s has no supplies annotation! Using anyway." % (lib.serialize()))
             return True
+        # If we are using MMMC assume all libraries will be used
+        # TODO: Read the corners and filter out libraries that don't match any of them
+        #  Requires a refactor because MMMCCorner parsing is only in HammerTool now
+        if self.get_setting("vlsi.inputs.mmmc_corners"):
+            return True
         return self.get_setting("vlsi.inputs.supplies.VDD") == lib.supplies.VDD and self.get_setting("vlsi.inputs.supplies.GND") == lib.supplies.GND
 
     @staticmethod


### PR DESCRIPTION
This is a bugfix after recent changes caused this filter to run on all lib reading.
It would have been better to check the corners for matching libraries but hammer-tech doesn't parse MMMCCorners yet. I've left a TODO for fixing that.