### PR TITLE
Always log stdout and stderr of lsf to file

### DIFF
--- a/src/hammer-vlsi/hammer_vlsi/submit_command.py
+++ b/src/hammer-vlsi/hammer_vlsi/submit_command.py
@@ -211,7 +211,7 @@ class HammerLSFSubmitCommand(HammerSubmitCommand):
     def bsub_args(self) -> List[str]:
         args = [self.settings.bsub_binary, "-K"]  # always use -K to block
         args.extend(["-o", self.settings.log_file if self.settings.log_file is not None else
-                           datetime.datetime.now().strftime("hammer-vlsi-bsub-%Y%m%d-%H%M%S.log")])  # always use -o to output to a file
+            datetime.datetime.now().strftime("hammer-vlsi-bsub-%Y%m%d-%H%M%S.log")])  # always use -o to log to a file
         if self.settings.queue is not None:
             args.extend(["-q", self.settings.queue])
         if self.settings.num_cpus is not None:

--- a/src/hammer-vlsi/hammer_vlsi/submit_command.py
+++ b/src/hammer-vlsi/hammer_vlsi/submit_command.py
@@ -10,6 +10,7 @@
 
 import atexit
 import subprocess
+import datetime
 from abc import abstractmethod
 from functools import reduce
 from typing import Any, Dict, List, NamedTuple, Optional
@@ -203,6 +204,7 @@ class HammerLSFSubmitCommand(HammerSubmitCommand):
 
     def bsub_args(self) -> List[str]:
         args = [self.settings.bsub_binary, "-K"]  # always use -K to block
+        args.extend(["-o", datetime.datetime.now().strftime("hammer-vlsi-bsub-%Y%m%d-%H%M%S.log")])  # always use -o to output to a file
         if self.settings.queue is not None:
             args.extend(["-q", self.settings.queue])
         if self.settings.num_cpus is not None:

--- a/src/hammer-vlsi/hammer_vlsi/submit_command.py
+++ b/src/hammer-vlsi/hammer_vlsi/submit_command.py
@@ -151,6 +151,7 @@ class HammerLSFSettings(NamedTuple('HammerLSFSettings', [
     ('bsub_binary', str),
     ('num_cpus', Optional[int]),
     ('queue', Optional[str]),
+    ('log_file', Optional[str]),
     ('extra_args', List[str])
 ])):
     __slots__ = ()
@@ -171,11 +172,16 @@ class HammerLSFSettings(NamedTuple('HammerLSFSettings', [
             queue = settings["queue"]
         except KeyError:
             queue = None
+        try:
+            log_file = settings["log_file"]
+        except KeyError:
+            log_file = None
 
         return HammerLSFSettings(
             bsub_binary=bsub_binary,
             num_cpus=num_cpus,
             queue=queue,
+            log_file=log_file,
             extra_args=get_or_else(settings["extra_args"], [])
         )
 
@@ -204,7 +210,8 @@ class HammerLSFSubmitCommand(HammerSubmitCommand):
 
     def bsub_args(self) -> List[str]:
         args = [self.settings.bsub_binary, "-K"]  # always use -K to block
-        args.extend(["-o", datetime.datetime.now().strftime("hammer-vlsi-bsub-%Y%m%d-%H%M%S.log")])  # always use -o to output to a file
+        args.extend(["-o", self.settings.log_file if self.settings.log_file is not None else
+                           datetime.datetime.now().strftime("hammer-vlsi-bsub-%Y%m%d-%H%M%S.log")])  # always use -o to output to a file
         if self.settings.queue is not None:
             args.extend(["-q", self.settings.queue])
         if self.settings.num_cpus is not None:

--- a/src/hammer-vlsi/test.py
+++ b/src/hammer-vlsi/test.py
@@ -862,6 +862,7 @@ class HammerSubmitCommandTestContext:
                 "synthesis.submit.settings": [{"lsf": {
                     "queue": "myqueue",
                     "num_cpus": 4,
+                    "log_file": "test_log.log",
                     "bsub_binary": os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "test",
                                                 "mock_bsub.sh"),
                     "extra_args": ("-R", "myresources")
@@ -925,17 +926,18 @@ class HammerSubmitCommandTest(unittest.TestCase):
             self.assertEqual(output[0], "BLOCKING is: 1")
             self.assertEqual(output[1], "QUEUE is: %s" % get_or_else(cmd.settings.queue, ""))
             self.assertEqual(output[2], "NUMCPU is: %d" % get_or_else(cmd.settings.num_cpus, 0))
+            self.assertEqual(output[3], "OUTPUT is: %s" % get_or_else(cmd.settings.log_file, ""))
 
             extra = cmd.settings.extra_args
             has_resource = 0
             if "-R" in extra:
                 has_resource = 1
-                self.assertEqual(output[3], "RESOURCE is: %s" % extra[extra.index("-R") + 1])
+                self.assertEqual(output[4], "RESOURCE is: %s" % extra[extra.index("-R") + 1])
             else:
                 raise NotImplementedError("You forgot to test the extra_args!")
 
-            self.assertEqual(output[3 + has_resource], "COMMAND is: %s" % ' '.join(c.echo_command))
-            self.assertEqual(output[4 + has_resource], ' '.join(c.echo_command_args))
+            self.assertEqual(output[4 + has_resource], "COMMAND is: %s" % ' '.join(c.echo_command))
+            self.assertEqual(output[5 + has_resource], ' '.join(c.echo_command_args))
 
 
 class HammerSignoffToolTestContext:

--- a/src/test/mock_bsub.sh
+++ b/src/test/mock_bsub.sh
@@ -21,6 +21,11 @@ case $key in
     shift
     shift
     ;;
+    -o)
+    OUTPUT="$2"
+    shift
+    shift
+    ;;
     -K)
     BLOCKING=1
     shift
@@ -35,6 +40,7 @@ done
 if [ ! -z "$BLOCKING" ]; then echo "BLOCKING is: $BLOCKING"; fi
 if [ ! -z "$QUEUE" ]; then echo "QUEUE is: $QUEUE"; fi
 if [ ! -z "$NUMCPU" ]; then echo "NUMCPU is: $NUMCPU"; fi
+if [ ! -z "$OUTPUT" ]; then echo "OUTPUT is: $OUTPUT"; fi
 if [ ! -z "$RESOURCE" ]; then echo "RESOURCE is: $RESOURCE"; fi
 echo "COMMAND is: ${POSITIONAL[@]}"
 exec ${POSITIONAL[@]}


### PR DESCRIPTION
Some tools won't produce output to their own log
or won't produce output until after the tool may fail
this makes sure we have something to show for our time