### PR TITLE
Change get_setting to use None as a default nullvalue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.log
 *rundir/
 /*.json
-src/test/output.json
+src/test/output*.json
 
 # Sphinx/doc junk
 doc/_build/

--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -399,13 +399,13 @@ class HammerTechnology:
         """
         tech_setting_key = "technology.{name}.extracted_tarballs_dir".format(name=self.name)
         if self.has_setting(tech_setting_key):
-            tech_setting = str(self.get_setting(tech_setting_key))  # type: str
-            if tech_setting != "null":
+            tech_setting = self.get_setting(tech_setting_key)  # type: Optional[str]
+            if tech_setting is not None:
                 return tech_setting
 
         # No tech setting
-        extracted_tarballs_dir_setting = str(self.get_setting("vlsi.technology.extracted_tarballs_dir"))  # type: str
-        if extracted_tarballs_dir_setting == "null":
+        extracted_tarballs_dir_setting = self.get_setting("vlsi.technology.extracted_tarballs_dir")  # type: Optional[str]
+        if extracted_tarballs_dir_setting is None:
             return os.path.join(self.cache_dir, "extracted")
         else:
             return extracted_tarballs_dir_setting

--- a/src/hammer-vlsi/hammer_vlsi/driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/driver.py
@@ -750,7 +750,7 @@ class HammerDriver:
         leaf_modules = set()  # type: Set[str]
         intermediate_modules = set()  # type: Set[str]
         top_module = str(self.database.get_setting("vlsi.inputs.hierarchical.top_module"))
-        if top_module == "" or top_module == "null":
+        if top_module == "" or top_module is None:
             raise ValueError("Cannot have a hierarchical flow if the top module is not set")
 
         # Node + outgoing edges (nodes that depend on us) + incoming edges (nodes we depend on)

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -695,7 +695,7 @@ class HammerTool(metaclass=ABCMeta):
         """Get the config for this tool."""
         return reduce(add_lists, map(lambda path: hammer_config.load_config_from_defaults(path), self.config_dirs))
 
-    def get_setting(self, key: str, nullvalue: Optional[str] = None) -> Any:
+    def get_setting(self, key: str, nullvalue: Any = None) -> Any:
         """
         Get a particular setting from the database.
 
@@ -703,10 +703,7 @@ class HammerTool(metaclass=ABCMeta):
         :param nullvalue: Value to return in case of null (leave as None to use the default).
         """
         try:
-            if nullvalue is None:
-                return self._database.get_setting(key)
-            else:
-                return self._database.get_setting(key, nullvalue)
+            return self._database.get_setting(key, nullvalue)
         except AttributeError:
             raise ValueError("Internal error: no database set by hammer-vlsi")
 

--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -590,7 +590,7 @@ class HammerDatabase:
         """Alias for has_setting()."""
         return self.has_setting(item)
 
-    def get_setting(self, key: str, nullvalue: Any = "null") -> Any:
+    def get_setting(self, key: str, nullvalue: Any = None) -> Any:
         """
         Retrieve the given key.
 


### PR DESCRIPTION
This makes it return slightly saner Nones instead of string "null"s. No current calls to get_setting use "null" so this seems safe.

It's also worth noting that you may want a null value that is not type `Optional[str]` (and in fact we do this in the calibre plugin).

@harrisonliew does this solve your issue on ucb-bar/hammer-cad-plugins#40 ?