### PR TITLE
Fix subst target identification

### DIFF
--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -203,13 +203,25 @@ def get_meta_directives() -> Dict[str, MetaDirective]:
         config_dict[key] = perform_subst(value)
 
     def subst_targets(key: str, value: Any) -> List[str]:
-        assert isinstance(value, str)
+        # subst can operate on either a string or a list
+
+        # subst_strings is e.g. ["${a} 1", "${b} 2"]
+        subst_strings = []  # type: List[str]
+        if isinstance(value, str):
+            subst_strings.append(value)
+        elif isinstance(value, list):
+            for i in value:
+                assert isinstance(i, str)
+            subst_strings = value
+        else:
+            raise ValueError("subst must operate on a str or List[str]; got {0} instead".format(value))
 
         output_vars = []  # type: List[str]
 
-        matches = re.finditer(__VARIABLE_EXPANSION_REGEX, value, re.DOTALL)
-        for match in matches:
-            output_vars.append(match.group(1))
+        for subst_value in subst_strings:
+            matches = re.finditer(__VARIABLE_EXPANSION_REGEX, subst_value, re.DOTALL)
+            for match in matches:
+                output_vars.append(match.group(1))
 
         return output_vars
 

--- a/src/hammer_config_test/test.py
+++ b/src/hammer_config_test/test.py
@@ -176,6 +176,19 @@ style: "waterfall"
         self.assertEqual(db.get_setting("foo.later"), "later")
         self.assertEqual(db.get_setting("foo.methodology"), "agile design")
 
+    def test_meta_lazysubst_array(self) -> None:
+        """
+        Check that lazysubst works correctly with an array.
+        """
+        db = hammer_config.HammerDatabase()
+        d = hammer_config.load_config_from_string("""
+        target: "foo"
+        array: ["${target}bar"]
+        array_meta: lazysubst
+        """, is_yaml=True)
+        db.update_core([d])
+        self.assertEqual(db.get_setting("array"), ["foobar"])
+
     def test_meta_append(self) -> None:
         """
         Test that the meta attribute "append" works.


### PR DESCRIPTION
Should now work correctly on arrays

Close #334