### PR TITLE
Add supply and cpf api

### DIFF
--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -108,10 +108,21 @@ cadence:
 # General VLSI inputs.
 # These will vary per run of hammer-vlsi.
 vlsi.inputs:
-  # Supply voltages.
+  # Supply voltages and names
+  # Supply Struct:
+  #   name (str) - The name of your supply's net
+  #   pin (Optional[str]) - The cell pin that this net should drive, no pins are connected when omitted
+  #   tie (Optional[str]) - Another supply this supply is tied to. Nets with this set will  not end up in your final layout.
+  # power (List(Supply)): A list of of all power net(s) in the design
+  # ground (List(Supply)): A list of all ground net(s) in the design
+  # VDD (str): The default voltage of the primary power net
+  # GND (str): The default voltage of the primary ground net
   supplies:
+    power: [{name: "VDD", pin: "VDD"}]
+    ground: [{name: "VSS", pin: "VSS"}]
     VDD: "0.85 V"
     GND: "0 V"
+
 
   hierarchical:
     # Hierarchical par mode. (str)

--- a/src/hammer-vlsi/generate_properties.py
+++ b/src/hammer-vlsi/generate_properties.py
@@ -142,10 +142,6 @@ def main(args) -> int:
                                                          "(optional) output ILM information for hierarchical mode"),
                                             InterfaceVar("output_gds", "str", "path to the output GDS file"),
                                             InterfaceVar("output_netlist", "str", "path to the output netlist file"),
-                                            InterfaceVar("power_nets", "List[str]",
-                                                         "list of all the power nets in the design"),
-                                            InterfaceVar("ground_nets", "List[str]",
-                                                         "list of all the ground nets in the design"),
                                             InterfaceVar("hcells_list", "List[str]",
                                                          "list of cells to explicitly map hierarchically in LVS")
 
@@ -181,8 +177,6 @@ def main(args) -> int:
                                   InterfaceVar("schematic_files", "List[str]",
                                                "path to the input SPICE or Verilog schematic files (e.g. *.v or *.spi)"),
                                   InterfaceVar("top_module", "str", "top RTL module"),
-                                  InterfaceVar("power_nets", "List[str]", "list of all the power nets in the design"),
-                                  InterfaceVar("ground_nets", "List[str]", "list of all the ground nets in the design"),
                                   InterfaceVar("hcells_list", "List[str]",
                                                "list of cells to explicitly map hierarchically in LVS")
                               ],

--- a/src/hammer-vlsi/generate_properties.py
+++ b/src/hammer-vlsi/generate_properties.py
@@ -113,8 +113,7 @@ def main(args) -> int:
                                     filename="hammer_vlsi/hammer_vlsi_impl.py",
                                     inputs=[
                                         InterfaceVar("input_files", "List[str]",
-                                                     "input collection of source RTL files (e.g. *.v)"),
-                                        InterfaceVar("top_module", "str", "top-level module")
+                                                     "input collection of source RTL files (e.g. *.v)")
                                     ],
                                     outputs=[
                                         InterfaceVar("output_files", "List[str]",
@@ -130,7 +129,6 @@ def main(args) -> int:
                                         inputs=[
                                             InterfaceVar("input_files", "List[str]",
                                                          "input post-synthesis netlist files"),
-                                            InterfaceVar("top_module", "str", "top RTL module"),
                                             InterfaceVar("post_synth_sdc", "Optional[str]",
                                                          "(optional) input post-synthesis SDC constraint file")
                                         ],
@@ -164,8 +162,7 @@ def main(args) -> int:
     HammerDRCTool = Interface(module="HammerDRCTool",
                               filename="hammer_vlsi/hammer_vlsi_impl.py",
                               inputs=[
-                                  InterfaceVar("layout_file", "str", "path to the input layout file (e.g. a *.gds)"),
-                                  InterfaceVar("top_module", "str", "top RTL module")
+                                  InterfaceVar("layout_file", "str", "path to the input layout file (e.g. a *.gds)")
                               ],
                               outputs=[]
                               )
@@ -176,7 +173,6 @@ def main(args) -> int:
                                   InterfaceVar("layout_file", "str", "path to the input layout file (e.g. a *.gds)"),
                                   InterfaceVar("schematic_files", "List[str]",
                                                "path to the input SPICE or Verilog schematic files (e.g. *.v or *.spi)"),
-                                  InterfaceVar("top_module", "str", "top RTL module"),
                                   InterfaceVar("hcells_list", "List[str]",
                                                "list of cells to explicitly map hierarchically in LVS")
                               ],

--- a/src/hammer-vlsi/hammer_vlsi/constraints.py
+++ b/src/hammer-vlsi/hammer_vlsi/constraints.py
@@ -14,7 +14,7 @@ from typing import Dict, NamedTuple, Optional, List, Any
 from hammer_utils import reverse_dict
 from .units import TimeValue, VoltageValue, TemperatureValue
 
-__all__ = ['ILMStruct', 'SRAMParameters', 'ClockPort', 'OutputLoadConstraint',
+__all__ = ['ILMStruct', 'SRAMParameters', 'Supply', 'ClockPort', 'OutputLoadConstraint',
            'DelayConstraint', 'ObstructionType', 'PlacementConstraintType',
            'Margins', 'PlacementConstraint', 'MMMCCornerType', 'MMMCCorner']
 
@@ -71,6 +71,12 @@ class SRAMParameters(NamedTuple('SRAMParameters', [
             vt=str(d["vt"]),
             mux=int(d["mux"])
         )
+
+Supply = NamedTuple('Supply', [
+    ('name', str),
+    ('pin', Optional[str]),
+    ('tie', Optional[str])
+])
 
 ClockPort = NamedTuple('ClockPort', [
     ('name', str),

--- a/src/hammer-vlsi/hammer_vlsi/driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/driver.py
@@ -390,8 +390,6 @@ class HammerDriver:
         lvs_tool.schematic_files = self.database.get_setting("lvs.inputs.schematic_files", nullvalue=[])
         lvs_tool.layout_file = self.database.get_setting("lvs.inputs.layout_file", nullvalue="")
         lvs_tool.top_module = self.database.get_setting("lvs.inputs.top_module", nullvalue="")
-        lvs_tool.power_nets = self.database.get_setting("lvs.inputs.power_nets", nullvalue=[])
-        lvs_tool.ground_nets = self.database.get_setting("lvs.inputs.ground_nets", nullvalue=[])
         lvs_tool.hcells_list = self.database.get_setting("lvs.inputs.hcells_list", nullvalue=[])
         missing_inputs = False
         if lvs_tool.top_module == "":
@@ -665,8 +663,6 @@ class HammerDriver:
                 "lvs.inputs.layout_file": output_dict["par.outputs.output_gds"],
                 "lvs.inputs.schematic_files": [output_dict["par.outputs.output_netlist"]],
                 # TODO(johnwright): add ILM netlists
-                "lvs.inputs.power_nets": output_dict["par.outputs.power_nets"],
-                "lvs.inputs.ground_nets": output_dict["par.outputs.ground_nets"],
                 "lvs.inputs.hcells_list": output_dict["par.outputs.hcells_list"],
                 "vlsi.builtins.is_complete": False
             }  # type: Dict[str, Any]

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -317,6 +317,25 @@ class HammerTool(metaclass=ABCMeta):
         self._submit_command = value
 
     @property
+    def top_module(self) -> str:
+        """
+        Get the top-level module.
+
+        :return: The top-level module.
+        """
+        try:
+            return self.attr_getter("_top_module", None)
+        except AttributeError:
+            raise ValueError("Nothing set for the top-level module yet")
+
+    @top_module.setter
+    def top_module(self, value: str) -> None:
+        """Set the top-level module."""
+        if not (isinstance(value, str)):
+            raise TypeError("top_module must be a str")
+        self.attr_setter("_top_module", value)
+
+    @property
     def logger(self) -> HammerVLSILoggingContext:
         """Get the logger for this tool."""
         try:

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -846,6 +846,30 @@ class HammerTool(metaclass=ABCMeta):
             output.append(clock)
         return output
 
+    def get_all_supplies(self, key: str) -> List[Supply]:
+        supplies = self.get_setting(key)
+        output = []  # type: List[Supply]
+        for raw_supply in supplies:
+            supply = Supply(name=raw_supply['name'],pin=None,tie=None)
+            if 'pin' in raw_supply:
+                supply = supply._replace(pin=raw_supply['pin'])
+            if 'tie' in raw_supply:
+                supply = supply._replace(tie=raw_supply['tie'])
+            output.append(supply)
+        return output
+
+    def get_all_power_nets(self) -> List[Supply]:
+        return self.get_all_supplies("vlsi.inputs.supplies.power")
+
+    def get_independent_power_nets(self) -> List[Supply]:
+        return list(filter(lambda x: x.tie is None, self.get_all_power_nets()))
+
+    def get_all_ground_nets(self) -> List[Supply]:
+        return self.get_all_supplies("vlsi.inputs.supplies.ground")
+
+    def get_independent_ground_nets(self) -> List[Supply]:
+        return list(filter(lambda x: x.tie is None, self.get_all_ground_nets()))
+
     def get_gds_map_file(self) -> Optional[str]:
         """
         Get a GDS map in accordance with settings in the Hammer IR.

--- a/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py
@@ -258,26 +258,6 @@ class HammerSynthesisTool(HammerTool):
         self.attr_setter("_input_files", value)
 
 
-    @property
-    def top_module(self) -> str:
-        """
-        Get the top-level module.
-
-        :return: The top-level module.
-        """
-        try:
-            return self.attr_getter("_top_module", None)
-        except AttributeError:
-            raise ValueError("Nothing set for the top-level module yet")
-
-    @top_module.setter
-    def top_module(self, value: str) -> None:
-        """Set the top-level module."""
-        if not (isinstance(value, str)):
-            raise TypeError("top_module must be a str")
-        self.attr_setter("_top_module", value)
-
-
     ### Outputs ###
 
     @property
@@ -359,26 +339,6 @@ class HammerPlaceAndRouteTool(HammerTool):
         if not (isinstance(value, List)):
             raise TypeError("input_files must be a List[str]")
         self.attr_setter("_input_files", value)
-
-
-    @property
-    def top_module(self) -> str:
-        """
-        Get the top RTL module.
-
-        :return: The top RTL module.
-        """
-        try:
-            return self.attr_getter("_top_module", None)
-        except AttributeError:
-            raise ValueError("Nothing set for the top RTL module yet")
-
-    @top_module.setter
-    def top_module(self, value: str) -> None:
-        """Set the top RTL module."""
-        if not (isinstance(value, str)):
-            raise TypeError("top_module must be a str")
-        self.attr_setter("_top_module", value)
 
 
     @property
@@ -491,25 +451,6 @@ class HammerSignoffTool(HammerTool):
 
     ### Inputs ###
 
-    @property
-    def top_module(self) -> str:
-        """
-        Get the top-level module.
-
-        :return: The top-level module.
-        """
-        try:
-            return self.attr_getter("_top_module", None)
-        except AttributeError:
-            raise ValueError("Nothing set for the top-level module yet")
-
-    @top_module.setter
-    def top_module(self, value: str) -> None:
-        """Set the top-level module."""
-        if not (isinstance(value, str)):
-            raise TypeError("top_module must be a str")
-        self.attr_setter("_top_module", value)
-
     ### Outputs ###
     @abstractmethod
     def signoff_results(self) -> int:
@@ -604,26 +545,6 @@ class HammerDRCTool(HammerSignoffTool):
         if not (isinstance(value, str)):
             raise TypeError("layout_file must be a str")
         self.attr_setter("_layout_file", value)
-
-
-    @property
-    def top_module(self) -> str:
-        """
-        Get the top RTL module.
-
-        :return: The top RTL module.
-        """
-        try:
-            return self.attr_getter("_top_module", None)
-        except AttributeError:
-            raise ValueError("Nothing set for the top RTL module yet")
-
-    @top_module.setter
-    def top_module(self, value: str) -> None:
-        """Set the top RTL module."""
-        if not (isinstance(value, str)):
-            raise TypeError("top_module must be a str")
-        self.attr_setter("_top_module", value)
 
 
     ### Outputs ###
@@ -736,26 +657,6 @@ class HammerLVSTool(HammerSignoffTool):
         if not (isinstance(value, List)):
             raise TypeError("schematic_files must be a List[str]")
         self.attr_setter("_schematic_files", value)
-
-
-    @property
-    def top_module(self) -> str:
-        """
-        Get the top RTL module.
-
-        :return: The top RTL module.
-        """
-        try:
-            return self.attr_getter("_top_module", None)
-        except AttributeError:
-            raise ValueError("Nothing set for the top RTL module yet")
-
-    @top_module.setter
-    def top_module(self, value: str) -> None:
-        """Set the top RTL module."""
-        if not (isinstance(value, str)):
-            raise TypeError("top_module must be a str")
-        self.attr_setter("_top_module", value)
 
 
     @property

--- a/src/hammer-vlsi/par/nop.py
+++ b/src/hammer-vlsi/par/nop.py
@@ -14,8 +14,6 @@ class NopPlaceAndRoute(HammerPlaceAndRouteTool, DummyHammerTool):
         self.output_ilms = []
         self.output_gds = "/dev/null"
         self.output_netlist = "/dev/null"
-        self.power_nets = []
-        self.ground_nets = []
         self.hcells_list = []
         return True
 

--- a/src/hammer-vlsi/test.py
+++ b/src/hammer-vlsi/test.py
@@ -973,8 +973,6 @@ class HammerSignoffToolTestContext:
         if self._tool_type is "lvs":
             json_content.update({
                 "lvs.inputs.schematic_files": ["/dev/null"],
-                "lvs.inputs.power_nets": ["VDD"],
-                "lvs.inputs.ground_nets": ["VSS"],
                 "lvs.inputs.hcells_list": []
             })
 

--- a/src/hammer-vlsi/vivado_core.py
+++ b/src/hammer-vlsi/vivado_core.py
@@ -23,11 +23,6 @@ class VivadoCommon(HammerTool, metaclass=ABCMeta):
         new_dict = deepdict(super().env_vars)
         return new_dict
 
-    @property
-    @abstractmethod
-    def top_module(self) -> str:
-        pass
-
     def append(self, cmd: str) -> None:
         self.tcl_append(cmd, self.output)
 


### PR DESCRIPTION
Metadata: rebase and merge

Add the ability to generate a CPF power spec.
This also includes a simple supply net API to enable the CPF generation.
This only supports single domain power specifications for now.

I also threw in a free refactor (for that negative line count despite adding a feature achievement) 

I tested this on a downstream template, it works as before not breaking SYN, PAR, or LVS.