### PR TITLE
Add an API for placing and assigning bumps

### DIFF
--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -277,6 +277,22 @@ vlsi.inputs:
   # SRAM Parameters
   sram_parameters: []
 
+  # Bumps settings struct, Optional
+  # Currently only support rectangular, evenly-spaced grids
+  # Bumps are numbered starting with 1,1 in the lower left
+  # Unassigned bumps will be removed, special name "+NC", leaves bump unconnected
+  # setting top-level bummps to null corresponds to a no bump chip
+  bumps: null
+  # BumpsDefinition struct members
+  # - x (int) - number of bumps in the x dimension
+  # - y (int) - number of bumps in the y dimension
+  # - pitch (float) - pitch of bumps in microns
+  # - cell (str) - Name of bump cell
+  # assignments - List of BumpAssignment structs
+  #  - name (str) - The name of the net being assigned to a bump
+  #  - x (int) - The X coordinate of the bump assigned to this net
+  #  - y (int) - The Y coordinate of the bump assigned to this net
+
 vlsi.submit:
   # The submit command to use. "none", "local", or null will run on the current host. See hammer_submit_command.py for other options.
   command: "local"

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -67,6 +67,11 @@ vlsi.technology:
   # Required for some CAD tools to function properly.
   placement_site: null
 
+  # Top cut/via layer for blockage under bumps. (Optional[str])
+  # Only used if using vlsi.inputs.bumps
+  # TODO: remove this after stackup supports vias ucb-bar/hammer#354
+  bump_block_cut_layer: null
+
   # Extra semiconductor IP libraries/stdcell libs/hard macros. (List[ExtraLibrary])
   # Used for non-technology-vendor-provided custom IP blocks.
   # ExtraLibrary is a struct with two fields:

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -282,19 +282,26 @@ vlsi.inputs:
   # SRAM Parameters
   sram_parameters: []
 
-  # Bumps settings struct, Optional
+  # Bumps settings mode. (str)
+  # Specifies how to setup the bumps for your design.
   # Currently only support rectangular, evenly-spaced grids
   # Bumps are numbered starting with 1,1 in the lower left
-  # Unassigned bumps will be removed, special name "+NC", leaves bump unconnected
-  # setting top-level bummps to null corresponds to a no bump chip
+  # Unassigned bumps will be removed, bumps with no_connect set will be present but unconnected
+  # Valid options:
+  # manual - Use the bumps struct to create and assign bumps
+  # empty - Do not add any bumps
+  bumps_mode: empty
+  # Bumps settings struct only required if above key is set to manual
   bumps: null
   # BumpsDefinition struct members
   # - x (int) - number of bumps in the x dimension
   # - y (int) - number of bumps in the y dimension
   # - pitch (float) - pitch of bumps in microns
   # - cell (str) - Name of bump cell
-  # assignments - List of BumpAssignment structs
-  #  - name (str) - The name of the net being assigned to a bump
+  # assignments - List of BumpAssignment structs. You must specify one of name or no_connect.
+  # If both are specified the bump will be left unconnected
+  #  - name (Optional[str]) - The name of the net being assigned to a bump
+  #  - no_connect (Optional[bool]) - If True the bump will be present but unconnected
   #  - x (int) - The X coordinate of the bump assigned to this net
   #  - y (int) - The Y coordinate of the bump assigned to this net
 

--- a/src/hammer-vlsi/hammer_vlsi/constraints.py
+++ b/src/hammer-vlsi/hammer_vlsi/constraints.py
@@ -80,7 +80,8 @@ Supply = NamedTuple('Supply', [
 ])
 
 BumpAssignment = NamedTuple('BumpAssignment', [
-    ('name', str),
+    ('name', Optional[str]),
+    ('no_connect', Optional[bool]),
     ('x', int),
     ('y', int)
 ])

--- a/src/hammer-vlsi/hammer_vlsi/constraints.py
+++ b/src/hammer-vlsi/hammer_vlsi/constraints.py
@@ -14,7 +14,8 @@ from typing import Dict, NamedTuple, Optional, List, Any
 from hammer_utils import reverse_dict
 from .units import TimeValue, VoltageValue, TemperatureValue
 
-__all__ = ['ILMStruct', 'SRAMParameters', 'Supply', 'ClockPort', 'OutputLoadConstraint',
+__all__ = ['ILMStruct', 'SRAMParameters', 'Supply', 'BumpAssignment',
+           'BumpsDefinition', 'ClockPort', 'OutputLoadConstraint',
            'DelayConstraint', 'ObstructionType', 'PlacementConstraintType',
            'Margins', 'PlacementConstraint', 'MMMCCornerType', 'MMMCCorner']
 
@@ -76,6 +77,20 @@ Supply = NamedTuple('Supply', [
     ('name', str),
     ('pin', Optional[str]),
     ('tie', Optional[str])
+])
+
+BumpAssignment = NamedTuple('BumpAssignment', [
+    ('name', str),
+    ('x', int),
+    ('y', int)
+])
+
+BumpsDefinition = NamedTuple('BumpsDefinition', [
+    ('x', int),
+    ('y', int),
+    ('pitch', float),
+    ('cell', str),
+    ('assignments', List[BumpAssignment])
 ])
 
 ClockPort = NamedTuple('ClockPort', [

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -896,6 +896,7 @@ class HammerTool(metaclass=ABCMeta):
         elif bumps_mode != "manual":
             self.logger.error("Invalid bumps_mode:{m}, only empty or manual supported. Assuming empty.".format(
                 m=bumps_mode))
+            return None
         assignments = []  # type: List[BumpAssignment]
         for raw_assign in self.get_setting("vlsi.inputs.bumps.assignments"):
             name = None if not "name" in raw_assign else raw_assign["name"]

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -891,7 +891,7 @@ class HammerTool(metaclass=ABCMeta):
 
     def get_bumps(self) -> Optional[BumpsDefinition]:
         bumps = self.get_setting("vlsi.inputs.bumps")
-        if bumps is None or bumps == "null":
+        if bumps is None:
             return None
         assignments = []  # type: List[BumpAssignment]
         for raw_assign in bumps["assignments"]:

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -890,15 +890,28 @@ class HammerTool(metaclass=ABCMeta):
         return list(filter(lambda x: x.tie is None, self.get_all_ground_nets()))
 
     def get_bumps(self) -> Optional[BumpsDefinition]:
-        bumps = self.get_setting("vlsi.inputs.bumps")
-        if bumps is None:
+        bumps_mode = self.get_setting("vlsi.inputs.bumps_mode")
+        if bumps_mode == "empty":
             return None
+        elif bumps_mode != "manual":
+            self.logger.error("Invalid bumps_mode:{m}, only empty or manual supported. Assuming empty.".format(
+                m=bumps_mode))
         assignments = []  # type: List[BumpAssignment]
-        for raw_assign in bumps["assignments"]:
-            assignments.append(BumpAssignment(name=raw_assign["name"],
-                x=raw_assign["x"], y=raw_assign["y"]))
-        return BumpsDefinition(x=bumps["x"], y=bumps["y"] ,pitch=bumps["pitch"],
-            cell=bumps["cell"], assignments=assignments)
+        for raw_assign in self.get_setting("vlsi.inputs.bumps.assignments"):
+            name = None if not "name" in raw_assign else raw_assign["name"]
+            no_con = False if not "no_connect" in raw_assign else raw_assign["no_connect"]
+            x = raw_assign["x"]
+            y = raw_assign["y"]
+            if name is None and not no_con:
+                self.logger.warning("Invalid bump assignment, neither name nor no_connect specified for bump {x},{y}. Assuming it should be unassigned".format(
+                    x=x, y=y))
+            else:
+                assignments.append(BumpAssignment(name=name, no_connect=no_con,
+                    x=x, y=y))
+        return BumpsDefinition(x=self.get_setting("vlsi.inputs.bumps.x"),
+            y=self.get_setting("vlsi.inputs.bumps.y"),
+            pitch=self.get_setting("vlsi.inputs.bumps.pitch"),
+            cell=self.get_setting("vlsi.inputs.bumps.cell"), assignments=assignments)
 
     def get_gds_map_file(self) -> Optional[str]:
         """

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -889,6 +889,17 @@ class HammerTool(metaclass=ABCMeta):
     def get_independent_ground_nets(self) -> List[Supply]:
         return list(filter(lambda x: x.tie is None, self.get_all_ground_nets()))
 
+    def get_bumps(self) -> Optional[BumpsDefinition]:
+        bumps = self.get_setting("vlsi.inputs.bumps")
+        if bumps is None or bumps == "null":
+            return None
+        assignments = []  # type: List[BumpAssignment]
+        for raw_assign in bumps["assignments"]:
+            assignments.append(BumpAssignment(name=raw_assign["name"],
+                x=raw_assign["x"], y=raw_assign["y"]))
+        return BumpsDefinition(x=bumps["x"], y=bumps["y"] ,pitch=bumps["pitch"],
+            cell=bumps["cell"], assignments=assignments)
+
     def get_gds_map_file(self) -> Optional[str]:
         """
         Get a GDS map in accordance with settings in the Hammer IR.

--- a/src/hammer-vlsi/test.py
+++ b/src/hammer-vlsi/test.py
@@ -593,6 +593,7 @@ export lol=abc"cat"
 
          # TODO: We expect 1 warning and 1 error, check this somehow
          my_bumps = test.get_bumps()
+         assert my_bumps is not None
          # Only one of the assignments is invalid so the above 7 becomes 6
          self.assertEqual(len(my_bumps.assignments), 6)
 


### PR DESCRIPTION
This is a new optional API that allows the user to specify
a rectangular set of bumps and assign them to signals,
power/ground, leave them unconnected, or remove them.