### PR TITLE
Top layer placement api

### DIFF
--- a/src/hammer-tech/stackup.py
+++ b/src/hammer-tech/stackup.py
@@ -337,3 +337,15 @@ class Stackup(NamedTuple('Stackup', [
             if m.name == name:
                 return m
         raise ValueError("Metal named %s is not defined in stackup %s" % (name, self.name))
+
+    def get_metal_by_index(self, index: int) -> Metal:
+        """
+        Get a given metal layer by index.
+
+        :param index: Index of the metal layer
+        :return: A metal layer object
+        """
+        for m in self.metals:
+            if m.index == index:
+                return m
+        raise ValueError("Metal with index %d is not defined in stackup %s" % (index, self.name))

--- a/src/hammer-vlsi/cli_driver_test.py
+++ b/src/hammer-vlsi/cli_driver_test.py
@@ -349,6 +349,7 @@ class CLIDriverTest(unittest.TestCase):
                 height=10.0,
                 orientation=None,
                 margins=None,
+                top_layer=None,
                 layers=None,
                 obs_types=None).to_dict()
             output["vlsi.inputs.default_output_load"] = 1

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -388,6 +388,10 @@ par:
   power_straps_mode: blank
   power_straps_script_contents: null
 
+  # Spacing around blocks and hardmacros in microns
+  # Used by power straps and floorplanning
+  blockage_spacing: 0.0
+
   # If power_straps_mode is 'generate', which method to use.
   # Currently, the valid options are:
   # - by_tracks - Specify the power strap plan per layer in terms of tracks
@@ -399,7 +403,8 @@ par:
     by_tracks:
       # Spacing from end of strap to a block or blockage
       # Overrideable by appending _<layer name>
-      blockage_spacing: 0.0
+      blockage_spacing: "par.blockage_spacing"
+      blockage_spacing_meta: lazycrossref
 
       # Number of routing tracks to be consumed by an individual strap
       # Overrideable by appending _<layer name>

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -234,6 +234,8 @@ vlsi.inputs:
   # y (float) - y coordinate in um
   # width (float) - width in um
   # height (float) - height in um
+  # top_layer (str) - Optional: Specifies the highest layer used by this hardmacro
+  #   If specified will be used to keep other wires away from this hardmacro
   # layers (List[str]) - Optional: only used for obstruction type. 
   #   If specified, a list of strings that enumerates layer(s) blocked by the obstruction otherwise all layers are blocked
   # obs_types (List[str]) - Required for obstruction type. A list of one or more of the following:

--- a/src/hammer-vlsi/hammer_vlsi/constraints.py
+++ b/src/hammer-vlsi/hammer_vlsi/constraints.py
@@ -217,6 +217,7 @@ class PlacementConstraint(NamedTuple('PlacementConstraint', [
     ('height', float),
     ('orientation', Optional[str]),
     ('margins', Optional[Margins]),
+    ('top_layer', Optional[str]),
     ('layers', Optional[List[str]]),
     ('obs_types', Optional[List[ObstructionType]])
 ])):
@@ -228,6 +229,7 @@ class PlacementConstraint(NamedTuple('PlacementConstraint', [
             str(constraint["type"]))
         margins = None  # type: Optional[Margins]
         orientation = None  # type: Optional[str]
+        top_layer = None  # type: Optional[str]
         layers = None  # type: Optional[List[str]]
         obs_types = None  # type: Optional[List[ObstructionType]]
         if constraint_type == PlacementConstraintType.TopLevel:
@@ -240,6 +242,8 @@ class PlacementConstraint(NamedTuple('PlacementConstraint', [
             )
         if "orientation" in constraint:
             orientation = str(constraint["orientation"])
+        if "top_layer" in constraint:
+            top_layer = str(constraint["top_layer"])
         if "layers" in constraint:
             layers = []
             for layer in constraint["layers"]:
@@ -258,6 +262,7 @@ class PlacementConstraint(NamedTuple('PlacementConstraint', [
             height=float(constraint["height"]),
             orientation=orientation,
             margins=margins,
+            top_layer=top_layer,
             layers=layers,
             obs_types=obs_types
         )
@@ -280,6 +285,8 @@ class PlacementConstraint(NamedTuple('PlacementConstraint', [
                 "right": self.margins.right,
                 "top": self.margins.top
             }})
+        if self.top_layer is not None:
+            output.update({"top_layer": self.top_layer})
         if self.layers is not None:
             output.update({"layers": self.layers})
         if self.obs_types is not None:


### PR DESCRIPTION
This upstreams something I always end up adding in hooks. A lot of hardmacros will need keep-outs around them because their pins cannot handle power grids or standard cells directly adjacent.

This API is intended to be used to implement these keep-outs. The top-layer is optional and no keep-out should be created if it is not specified if it is specified the keep-out will be up and including the layer specified in the key.