### PR TITLE
Add pin assignment API

### DIFF
--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -312,6 +312,25 @@ vlsi.inputs:
     #  - y (int) - The Y coordinate of the bump assigned to this net
     assignments: []
 
+  # Pin placement mode. (str)
+  # Specifies how to arrange pins for your design.
+  # Valid options:
+  # none - This mode lets the CAD tool do whatever it wants (providing no constraints).
+  #   Typically this is sane but unpredictable.
+  # generated - Use the assignments list below
+  # auto - is unsupported but should look at hierarchy and guess where pins should go
+  pin_mode: none
+  pin:
+    # List of PinAssignment Structs.
+    #   You must specify pins and one of either macro or layers and side.
+    # - pins (str) - The name(s) of pins that will be assigned.
+    # - side (Optional[str]) - The side of the chip/block these pins will be palced along.
+    #   One of "left", "right", "top", "bottom"
+    # - layers (Optional[List[str]]) - The metal layers that these pins will be placed on.
+    # - macro (Optional[bool]) - If true this pins come from an internal macro
+    #   and should just be noted as such without placing them.
+    assignments: []
+
 vlsi.submit:
   # The submit command to use. "none", "local", or null will run on the current host. See hammer_submit_command.py for other options.
   command: "local"

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -322,13 +322,16 @@ vlsi.inputs:
   pin_mode: none
   pin:
     # List of PinAssignment Structs.
-    #   You must specify pins and one of either macro or layers and side.
+    #   You must specify pins and one of either preplaced or layers and side.
     # - pins (str) - The name(s) of pins that will be assigned.
     # - side (Optional[str]) - The side of the chip/block these pins will be placed along.
     #   One of "left", "right", "top", "bottom"
     # - layers (Optional[List[str]]) - The metal layers that these pins will be placed on.
-    # - macro (Optional[bool]) - If true this pins come from an internal macro
-    #   and should just be noted as such without placing them.
+    # - preplaced (Optional[bool]) - If true, these pins are preplaced by some internal block or macro.
+    #   This is telling the tool that these pins are on an internal block and I want them
+    #   "placed" where they are currently on the internal block. This can be used for IP
+    #   that directly connects to bumps, or signals that will be connected by abutment,
+    #   and much more.
     assignments: []
 
 vlsi.submit:

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -323,7 +323,9 @@ vlsi.inputs:
   pin:
     # List of PinAssignment Structs.
     #   You must specify pins and one of either preplaced or layers and side.
-    # - pins (str) - The name(s) of pins that will be assigned.
+    # - pins (str) - The name(s) of pins that will be assigned. All current backends support
+    #   * as wildcards in the pin names. So "*" for all pins or "io_tl_a*" for all pins that
+    #   start with "io_tl_a".
     # - side (Optional[str]) - The side of the chip/block these pins will be placed along.
     #   One of "left", "right", "top", "bottom"
     # - layers (Optional[List[str]]) - The metal layers that these pins will be placed on.

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -318,7 +318,7 @@ vlsi.inputs:
   # none - This mode lets the CAD tool do whatever it wants (providing no constraints).
   #   Typically this is sane but unpredictable.
   # generated - Use the assignments list below
-  # auto - is unsupported but should look at hierarchy and guess where pins should go
+  # auto - (not implemented yet) looks at the hierarchy and guess where pins should go
   pin_mode: none
   pin:
     # List of PinAssignment Structs.

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -324,7 +324,7 @@ vlsi.inputs:
     # List of PinAssignment Structs.
     #   You must specify pins and one of either macro or layers and side.
     # - pins (str) - The name(s) of pins that will be assigned.
-    # - side (Optional[str]) - The side of the chip/block these pins will be palced along.
+    # - side (Optional[str]) - The side of the chip/block these pins will be placed along.
     #   One of "left", "right", "top", "bottom"
     # - layers (Optional[List[str]]) - The metal layers that these pins will be placed on.
     # - macro (Optional[bool]) - If true this pins come from an internal macro

--- a/src/hammer-vlsi/hammer_vlsi/constraints.py
+++ b/src/hammer-vlsi/hammer_vlsi/constraints.py
@@ -14,10 +14,11 @@ from typing import Dict, NamedTuple, Optional, List, Any
 from hammer_utils import reverse_dict
 from .units import TimeValue, VoltageValue, TemperatureValue
 
-__all__ = ['ILMStruct', 'SRAMParameters', 'Supply', 'BumpAssignment',
-           'BumpsDefinition', 'ClockPort', 'OutputLoadConstraint',
-           'DelayConstraint', 'ObstructionType', 'PlacementConstraintType',
-           'Margins', 'PlacementConstraint', 'MMMCCornerType', 'MMMCCorner']
+__all__ = ['ILMStruct', 'SRAMParameters', 'Supply', 'PinAssignment',
+           'BumpAssignment', 'BumpsDefinition', 'ClockPort',
+           'OutputLoadConstraint', 'DelayConstraint', 'ObstructionType',
+           'PlacementConstraintType', 'Margins', 'PlacementConstraint',
+           'MMMCCornerType', 'MMMCCorner']
 
 
 # Struct that holds various paths related to ILMs.
@@ -77,6 +78,13 @@ Supply = NamedTuple('Supply', [
     ('name', str),
     ('pin', Optional[str]),
     ('tie', Optional[str])
+])
+
+PinAssignment = NamedTuple('PinAssignment', [
+    ('pins', str),
+    ('side', Optional[str]),
+    ('layers', Optional[List[str]]),
+    ('macro', Optional[bool])
 ])
 
 BumpAssignment = NamedTuple('BumpAssignment', [

--- a/src/hammer-vlsi/hammer_vlsi/constraints.py
+++ b/src/hammer-vlsi/hammer_vlsi/constraints.py
@@ -84,7 +84,7 @@ PinAssignment = NamedTuple('PinAssignment', [
     ('pins', str),
     ('side', Optional[str]),
     ('layers', Optional[List[str]]),
-    ('macro', Optional[bool])
+    ('preplaced', Optional[bool])
 ])
 
 BumpAssignment = NamedTuple('BumpAssignment', [

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -937,15 +937,15 @@ class HammerTool(metaclass=ABCMeta):
             if not (side is None or side == "top" or side == "bottom" or side == "right" or side == "left") :
                 self.logger.warning("Pins {p} have invalid side {s}. Assuming pins will be handled by CAD tool.".format(p=pins, s=side))
                 continue
-            preplaced = False if not "preplaced" in raw_assign else raw_assign["preplaced"]
+            preplaced = raw_assign.get("preplaced", False)
             layers = [] if not "layers" in raw_assign else raw_assign["layers"]
             if preplaced:
-                if len(layers) != 0 or side != None:
+                if len(layers) != 0 or side is not None:
                     self.logger.warning("Pins {p} assigned as a preplaced pin with layers or side. Assuming pins are preplaced pins and ignoring layers and side.".format(p=pins))
                     assigns.append(PinAssignment(pins=pins, side=None, layers=[], preplaced=preplaced))
                     continue
             else:
-                if len(layers) == 0 or side == None:
+                if len(layers) == 0 or side is None:
                     self.logger.warning("Pins {p} assigned without layers or side. Assuming pins will be handled by CAD tool.".format(p=pins))
                     # No pin appended
                     continue

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -932,7 +932,7 @@ class HammerTool(metaclass=ABCMeta):
         for raw_assign in self.get_setting("vlsi.inputs.pin.assignments"):
             pins = str(raw_assign["pins"])  # type: str
             side = None if not "side" in raw_assign else raw_assign["side"]
-            if not (side == None or side == "top" or side == "bottom" or side == "right" or side == "left") :
+            if not (side is None or side == "top" or side == "bottom" or side == "right" or side == "left") :
                 self.logger.warning("Pins {p} have invalid side {s}. Assuming pins will be handled by CAD tool.".format(p=pins, s=side))
                 continue
             macro = False if not "macro" in raw_assign else raw_assign["macro"]

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -922,7 +922,9 @@ class HammerTool(metaclass=ABCMeta):
         pin_mode = str(self.get_setting("vlsi.inputs.pin_mode"))  # type: str
         if pin_mode == "none":
             return []
-        elif pin_mode != "generated":
+        elif pin_mode == "generated":
+            pass
+        else:
             self.logger.error(
                 "Invalid pin_mode {mode}. Using none pin mode.".format(mode=pin_mode))
             return []

--- a/src/hammer-vlsi/tech_test.py
+++ b/src/hammer-vlsi/tech_test.py
@@ -5,13 +5,15 @@
 #
 #  See LICENSE for licence details.
 
+# TODO: move this file out of hammer_vlsi.
+# See issue #318.
+
 import json
 import os
 import shutil
 import unittest
 
 from hammer_vlsi import HammerVLSISettings
-import test
 from typing import Any, Dict, List, Optional
 
 from hammer_logging import HammerVLSILogging
@@ -19,15 +21,14 @@ import hammer_tech
 from hammer_tech import LibraryFilter, Stackup, Metal, WidthSpacingTuple
 from hammer_utils import deepdict
 
+from test_tool_utils import HammerToolTestHelpers, DummyTool
+from tech_test_utils import HasGetTech
 
-class HammerTechnologyTest(unittest.TestCase):
+
+class HammerTechnologyTest(HasGetTech, unittest.TestCase):
     """
     Tests for the Hammer technology library (hammer_tech).
     """
-
-    # Workaround for not being able to mix-in test.HasGetTech directly
-    def get_tech(self, tech_opt: Optional[hammer_tech.HammerTechnology]) -> hammer_tech.HammerTechnology:
-        return test.HasGetTech.get_tech(self, tech_opt) # type: ignore
 
     def setUp(self) -> None:
         # Make sure the HAMMER_VLSI path is set correctly.
@@ -43,7 +44,7 @@ class HammerTechnologyTest(unittest.TestCase):
 
         import hammer_config
 
-        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
 
         def add_named_library(in_dict: Dict[str, Any]) -> Dict[str, Any]:
@@ -54,7 +55,7 @@ class HammerTechnologyTest(unittest.TestCase):
             })
             return out_dict
 
-        test.HammerToolTestHelpers.write_tech_json(tech_json_filename, add_named_library)
+        HammerToolTestHelpers.write_tech_json(tech_json_filename, add_named_library)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -107,7 +108,7 @@ class HammerTechnologyTest(unittest.TestCase):
         """
         import hammer_config
 
-        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
 
         def add_duplicates(in_dict: Dict[str, Any]) -> Dict[str, Any]:
@@ -122,7 +123,7 @@ class HammerTechnologyTest(unittest.TestCase):
             })
             return out_dict
 
-        test.HammerToolTestHelpers.write_tech_json(tech_json_filename, add_duplicates)
+        HammerToolTestHelpers.write_tech_json(tech_json_filename, add_duplicates)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -166,7 +167,7 @@ class HammerTechnologyTest(unittest.TestCase):
         """
         import hammer_config
 
-        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
 
         # Add defaults to specify tarball_dir.
@@ -175,7 +176,7 @@ class HammerTechnologyTest(unittest.TestCase):
                 "technology.dummy28.tarball_dir": tech_dir
             }))
 
-        test.HammerToolTestHelpers.write_tech_json(tech_json_filename, self.add_tarballs)
+        HammerToolTestHelpers.write_tech_json(tech_json_filename, self.add_tarballs)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -198,7 +199,7 @@ class HammerTechnologyTest(unittest.TestCase):
         """
         import hammer_config
 
-        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
 
         # Add defaults to specify tarball_dir.
@@ -208,7 +209,7 @@ class HammerTechnologyTest(unittest.TestCase):
                 "vlsi.technology.extracted_tarballs_dir": tech_dir_base
             }))
 
-        test.HammerToolTestHelpers.write_tech_json(tech_json_filename, self.add_tarballs)
+        HammerToolTestHelpers.write_tech_json(tech_json_filename, self.add_tarballs)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -232,7 +233,7 @@ class HammerTechnologyTest(unittest.TestCase):
         """
         import hammer_config
 
-        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
 
         # Add defaults to specify tarball_dir.
@@ -243,7 +244,7 @@ class HammerTechnologyTest(unittest.TestCase):
                 "technology.dummy28.extracted_tarballs_dir": tech_dir_base
             }))
 
-        test.HammerToolTestHelpers.write_tech_json(tech_json_filename, self.add_tarballs)
+        HammerToolTestHelpers.write_tech_json(tech_json_filename, self.add_tarballs)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -327,7 +328,7 @@ installs:
       base var: ""  # means relative to tech dir
 libraries: []
         """
-        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
 
         tech_yaml_filename = os.path.join(tech_dir, "dummy28.tech.yml")
         with open(tech_yaml_filename, "w") as f:  # pylint: disable=invalid-name
@@ -344,7 +345,7 @@ libraries: []
         """
         import hammer_config
 
-        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
 
         def add_gds_map(in_dict: Dict[str, Any]) -> Dict[str, Any]:
@@ -352,11 +353,11 @@ libraries: []
             out_dict.update({"gds map file": "test/gds_map_file"})
             return out_dict
 
-        test.HammerToolTestHelpers.write_tech_json(tech_json_filename, add_gds_map)
+        HammerToolTestHelpers.write_tech_json(tech_json_filename, add_gds_map)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
-        tool = test.DummyTool()
+        tool = DummyTool()
         tool.technology = tech
         database = hammer_config.HammerDatabase()
         tool.set_database(database)
@@ -386,10 +387,10 @@ libraries: []
         shutil.rmtree(tech_dir_base)
 
         # Create a new technology with no GDS map file.
-        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
 
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
-        test.HammerToolTestHelpers.write_tech_json(tech_json_filename)
+        HammerToolTestHelpers.write_tech_json(tech_json_filename)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -411,7 +412,7 @@ libraries: []
         """
         import hammer_config
 
-        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
 
         def add_dont_use_list(in_dict: Dict[str, Any]) -> Dict[str, Any]:
@@ -419,11 +420,11 @@ libraries: []
             out_dict.update({"dont use list": ["cell1", "cell2"]})
             return out_dict
 
-        test.HammerToolTestHelpers.write_tech_json(tech_json_filename, add_dont_use_list)
+        HammerToolTestHelpers.write_tech_json(tech_json_filename, add_dont_use_list)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
-        tool = test.DummyTool()
+        tool = DummyTool()
         tool.technology = tech
         database = hammer_config.HammerDatabase()
         tool.set_database(database)
@@ -455,10 +456,10 @@ libraries: []
         shutil.rmtree(tech_dir_base)
 
         # Create a new technology with no dont use list
-        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
 
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
-        test.HammerToolTestHelpers.write_tech_json(tech_json_filename)
+        HammerToolTestHelpers.write_tech_json(tech_json_filename)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -480,7 +481,7 @@ libraries: []
         """
         import hammer_config
 
-        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
 
         def add_lib_with_lef(d: Dict[str, Any]) -> Dict[str, Any]:
@@ -506,7 +507,7 @@ END LIBRARY
             })
             return r
 
-        test.HammerToolTestHelpers.write_tech_json(tech_json_filename, add_lib_with_lef)
+        HammerToolTestHelpers.write_tech_json(tech_json_filename, add_lib_with_lef)
         tech_opt = hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir)
         if tech_opt is None:
             self.assertTrue(False, "Unable to load technology")

--- a/src/hammer-vlsi/tech_test.py
+++ b/src/hammer-vlsi/tech_test.py
@@ -11,8 +11,8 @@ import shutil
 import unittest
 
 from hammer_vlsi import HammerVLSISettings
-from test import HammerToolTestHelpers, DummyTool, HasGetTech
-from typing import Any, Dict, List
+import test
+from typing import Any, Dict, List, Optional
 
 from hammer_logging import HammerVLSILogging
 import hammer_tech
@@ -20,10 +20,14 @@ from hammer_tech import LibraryFilter, Stackup, Metal, WidthSpacingTuple
 from hammer_utils import deepdict
 
 
-class HammerTechnologyTest(HasGetTech, unittest.TestCase):
+class HammerTechnologyTest(unittest.TestCase):
     """
     Tests for the Hammer technology library (hammer_tech).
     """
+
+    # Workaround for not being able to mix-in test.HasGetTech directly
+    def get_tech(self, tech_opt: Optional[hammer_tech.HammerTechnology]) -> hammer_tech.HammerTechnology:
+        return test.HasGetTech.get_tech(self, tech_opt) # type: ignore
 
     def setUp(self) -> None:
         # Make sure the HAMMER_VLSI path is set correctly.
@@ -39,7 +43,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
 
         import hammer_config
 
-        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
 
         def add_named_library(in_dict: Dict[str, Any]) -> Dict[str, Any]:
@@ -50,7 +54,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
             })
             return out_dict
 
-        HammerToolTestHelpers.write_tech_json(tech_json_filename, add_named_library)
+        test.HammerToolTestHelpers.write_tech_json(tech_json_filename, add_named_library)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -103,7 +107,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
         """
         import hammer_config
 
-        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
 
         def add_duplicates(in_dict: Dict[str, Any]) -> Dict[str, Any]:
@@ -118,7 +122,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
             })
             return out_dict
 
-        HammerToolTestHelpers.write_tech_json(tech_json_filename, add_duplicates)
+        test.HammerToolTestHelpers.write_tech_json(tech_json_filename, add_duplicates)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -162,7 +166,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
         """
         import hammer_config
 
-        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
 
         # Add defaults to specify tarball_dir.
@@ -171,7 +175,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
                 "technology.dummy28.tarball_dir": tech_dir
             }))
 
-        HammerToolTestHelpers.write_tech_json(tech_json_filename, self.add_tarballs)
+        test.HammerToolTestHelpers.write_tech_json(tech_json_filename, self.add_tarballs)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -194,7 +198,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
         """
         import hammer_config
 
-        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
 
         # Add defaults to specify tarball_dir.
@@ -204,7 +208,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
                 "vlsi.technology.extracted_tarballs_dir": tech_dir_base
             }))
 
-        HammerToolTestHelpers.write_tech_json(tech_json_filename, self.add_tarballs)
+        test.HammerToolTestHelpers.write_tech_json(tech_json_filename, self.add_tarballs)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -228,7 +232,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
         """
         import hammer_config
 
-        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
 
         # Add defaults to specify tarball_dir.
@@ -239,7 +243,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
                 "technology.dummy28.extracted_tarballs_dir": tech_dir_base
             }))
 
-        HammerToolTestHelpers.write_tech_json(tech_json_filename, self.add_tarballs)
+        test.HammerToolTestHelpers.write_tech_json(tech_json_filename, self.add_tarballs)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -323,7 +327,7 @@ installs:
       base var: ""  # means relative to tech dir
 libraries: []
         """
-        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
 
         tech_yaml_filename = os.path.join(tech_dir, "dummy28.tech.yml")
         with open(tech_yaml_filename, "w") as f:  # pylint: disable=invalid-name
@@ -340,7 +344,7 @@ libraries: []
         """
         import hammer_config
 
-        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
 
         def add_gds_map(in_dict: Dict[str, Any]) -> Dict[str, Any]:
@@ -348,11 +352,11 @@ libraries: []
             out_dict.update({"gds map file": "test/gds_map_file"})
             return out_dict
 
-        HammerToolTestHelpers.write_tech_json(tech_json_filename, add_gds_map)
+        test.HammerToolTestHelpers.write_tech_json(tech_json_filename, add_gds_map)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
-        tool = DummyTool()
+        tool = test.DummyTool()
         tool.technology = tech
         database = hammer_config.HammerDatabase()
         tool.set_database(database)
@@ -382,10 +386,10 @@ libraries: []
         shutil.rmtree(tech_dir_base)
 
         # Create a new technology with no GDS map file.
-        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
 
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
-        HammerToolTestHelpers.write_tech_json(tech_json_filename)
+        test.HammerToolTestHelpers.write_tech_json(tech_json_filename)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -407,7 +411,7 @@ libraries: []
         """
         import hammer_config
 
-        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
 
         def add_dont_use_list(in_dict: Dict[str, Any]) -> Dict[str, Any]:
@@ -415,11 +419,11 @@ libraries: []
             out_dict.update({"dont use list": ["cell1", "cell2"]})
             return out_dict
 
-        HammerToolTestHelpers.write_tech_json(tech_json_filename, add_dont_use_list)
+        test.HammerToolTestHelpers.write_tech_json(tech_json_filename, add_dont_use_list)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
-        tool = DummyTool()
+        tool = test.DummyTool()
         tool.technology = tech
         database = hammer_config.HammerDatabase()
         tool.set_database(database)
@@ -451,10 +455,10 @@ libraries: []
         shutil.rmtree(tech_dir_base)
 
         # Create a new technology with no dont use list
-        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
 
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
-        HammerToolTestHelpers.write_tech_json(tech_json_filename)
+        test.HammerToolTestHelpers.write_tech_json(tech_json_filename)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -476,7 +480,7 @@ libraries: []
         """
         import hammer_config
 
-        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_dir, tech_dir_base = test.HammerToolTestHelpers.create_tech_dir("dummy28")
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
 
         def add_lib_with_lef(d: Dict[str, Any]) -> Dict[str, Any]:
@@ -502,7 +506,7 @@ END LIBRARY
             })
             return r
 
-        HammerToolTestHelpers.write_tech_json(tech_json_filename, add_lib_with_lef)
+        test.HammerToolTestHelpers.write_tech_json(tech_json_filename, add_lib_with_lef)
         tech_opt = hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir)
         if tech_opt is None:
             self.assertTrue(False, "Unable to load technology")

--- a/src/hammer-vlsi/tech_test_utils.py
+++ b/src/hammer-vlsi/tech_test_utils.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+#  Helper and utility classes for testing hammer_tech.
+#
+#  See LICENSE for licence details.
+
+# TODO: move this file out of hammer_vlsi.
+# See issue #318.
+
+import unittest
+from typing import Optional
+
+import hammer_tech
+
+
+class HasGetTech(unittest.TestCase):
+    """
+    Helper mix-in that adds the convenience function get_tech.
+    """
+
+    def get_tech(self, tech_opt: Optional[hammer_tech.HammerTechnology]) -> hammer_tech.HammerTechnology:
+        """
+        Get the technology from the input parameter or raise an assertion.
+        :param tech_opt: Result of HammerTechnology.load_from_dir()
+        :return: Technology library or assertion will be raised.
+        """
+        self.assertTrue(tech_opt is not None, "Technology must be loaded")
+        assert tech_opt is not None  # type checking
+        return tech_opt

--- a/src/hammer-vlsi/test.py
+++ b/src/hammer-vlsi/test.py
@@ -665,10 +665,10 @@ export lol=abc"cat"
                          {"pins": "*", "side": "left", "layers": ["M4"]},
                          {"pins": "*", "side": "right", "layers": ["M2"]},
                          {"pins": "bad_side", "side": "right", "layers": ["M3"]},
-                         {"pins": "tx_n tx_p", "macro": true},
-                         {"pins": "bad_tx_n", "macro": true, "layers": ["M7"]},
-                         {"pins": "tx_n tx_p", "macro": true, "side": "right", "layers": ["M7"]},
-                         {"pins": "tx_n tx_p", "macro": true, "side": "right"},
+                         {"pins": "tx_n tx_p", "preplaced": true},
+                         {"pins": "bad_tx_n", "preplaced": true, "layers": ["M7"]},
+                         {"pins": "tx_n tx_p", "preplaced": true, "side": "right", "layers": ["M7"]},
+                         {"pins": "tx_n tx_p", "preplaced": true, "side": "right"},
                          {"pins": "*", "layers": ["M2"]},
                          {"pins": "*", "side": "bottom"},
                          {"pins": "no_layers"},
@@ -682,7 +682,7 @@ export lol=abc"cat"
          with HammerLoggingCaptureContext() as c:
              my_pins = test.get_pin_assignments()
          self.assertTrue(c.log_contains("Pins bad_side assigned layers "))
-         self.assertTrue(c.log_contains("Pins bad_tx_n assigned as a macro pin with layers"))
+         self.assertTrue(c.log_contains("Pins bad_tx_n assigned as a preplaced pin with layers"))
          self.assertTrue(c.log_contains("Pins no_layers assigned without layers"))
          self.assertTrue(c.log_contains("Pins wrong_side have invalid side"))
          assert my_pins is not None

--- a/src/hammer-vlsi/test.py
+++ b/src/hammer-vlsi/test.py
@@ -14,13 +14,16 @@ from abc import ABCMeta, abstractmethod
 from numbers import Number
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
 
+import tech_test
+
 import hammer_config
 import hammer_tech
 import hammer_vlsi
 from hammer_logging import HammerVLSIFileLogger, HammerVLSILogging, Level
 from hammer_logging.test import HammerLoggingCaptureContext
 from hammer_tech import LibraryFilter, Library, ExtraLibrary
-from hammer_utils import deeplist, get_or_else
+from hammer_utils import deeplist, deepdict, get_or_else
+
 
 
 class HasGetTech(unittest.TestCase):
@@ -611,6 +614,80 @@ export lol=abc"cat"
          assert my_bumps is not None
          # Only one of the assignments is invalid so the above 7 becomes 6
          self.assertEqual(len(my_bumps.assignments), 6)
+
+         # Cleanup
+         shutil.rmtree(tech_dir_base)
+         shutil.rmtree(test.run_dir)
+
+    def test_pins(self) -> None:
+         """
+         Test that HammerTool pin placement support works.
+         """
+         import hammer_config
+
+         tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
+         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
+         def add_stackup(in_dict: Dict[str, Any]) -> Dict[str, Any]:
+            out_dict = deepdict(in_dict)
+            out_dict["stackups"] = [tech_test.StackupTestHelper.create_test_stackup_dict(8)]
+            return out_dict
+         HammerToolTestHelpers.write_tech_json(tech_json_filename, add_stackup)
+         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
+         tech.cache_dir = tech_dir
+         tech.logger = HammerVLSILogging.context("")
+
+         test = DummyTool()
+         test.logger = HammerVLSILogging.context("")
+         test.run_dir = tempfile.mkdtemp()
+         test.technology = tech
+         database = hammer_config.HammerDatabase()
+         # Check bad mode string doesn't look at null dict
+         settings = """
+{
+     "vlsi.inputs.pin_mode": "auto"
+}
+"""
+         database.update_project([hammer_config.load_config_from_string(settings, is_yaml=False)])
+         test.set_database(database)
+
+         with HammerLoggingCaptureContext() as c:
+             my_pins = test.get_pin_assignments()
+         self.assertTrue(c.log_contains("Invalid pin_mode"))
+         assert len(my_pins) == 0, "Invalid pin_mode should assume empty pins"
+
+         settings = """
+ {
+     "technology.core.stackup": "StackupWith8Metals",
+     "vlsi.inputs.pin_mode": "generated",
+     "vlsi.inputs.pin.assignments": [
+                         {"pins": "*", "side": "top", "layers": ["M5", "M3"]},
+                         {"pins": "*", "side": "bottom", "layers": ["M5"]},
+                         {"pins": "*", "side": "left", "layers": ["M4"]},
+                         {"pins": "*", "side": "right", "layers": ["M2"]},
+                         {"pins": "bad_side", "side": "right", "layers": ["M3"]},
+                         {"pins": "tx_n tx_p", "macro": true},
+                         {"pins": "bad_tx_n", "macro": true, "layers": ["M7"]},
+                         {"pins": "tx_n tx_p", "macro": true, "side": "right", "layers": ["M7"]},
+                         {"pins": "tx_n tx_p", "macro": true, "side": "right"},
+                         {"pins": "*", "layers": ["M2"]},
+                         {"pins": "*", "side": "bottom"},
+                         {"pins": "no_layers"},
+                         {"pins": "wrong_side", "side": "upsidedown", "layers": ["M2"]}
+                     ]
+ }
+ """
+         database.update_project([hammer_config.load_config_from_string(settings, is_yaml=False)])
+         test.set_database(database)
+
+         with HammerLoggingCaptureContext() as c:
+             my_pins = test.get_pin_assignments()
+         self.assertTrue(c.log_contains("Pins bad_side assigned layers "))
+         self.assertTrue(c.log_contains("Pins bad_tx_n assigned as a macro pin with layers"))
+         self.assertTrue(c.log_contains("Pins no_layers assigned without layers"))
+         self.assertTrue(c.log_contains("Pins wrong_side have invalid side"))
+         assert my_pins is not None
+         # Only one of the assignments is invalid so the above 7 becomes 6
+         self.assertEqual(len(my_pins), 9)
 
          # Cleanup
          shutil.rmtree(tech_dir_base)

--- a/src/hammer-vlsi/test_tool_utils.py
+++ b/src/hammer-vlsi/test_tool_utils.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+#  Helper and utility classes for testing HammerTool.
+#
+#  See LICENSE for licence details.
+
+import json
+import os
+import tempfile
+from abc import ABCMeta, abstractmethod
+from numbers import Number
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import hammer_tech
+from hammer_tech import LibraryFilter
+import hammer_vlsi
+
+
+class SingleStepTool(hammer_vlsi.DummyHammerTool, metaclass=ABCMeta):
+    """
+    Helper class to define a single-step tool in tests.
+    """
+    @property
+    def steps(self) -> List[hammer_vlsi.HammerToolStep]:
+        return self.make_steps_from_methods([
+            self.step
+        ])
+
+    @abstractmethod
+    def step(self) -> bool:
+        """
+        Implement this method for the single step.
+        :return: True if the step passed
+        """
+        pass
+
+
+class DummyTool(SingleStepTool):
+    """
+    A dummy tool that does nothing and always passes.
+    """
+    def step(self) -> bool:
+        return True
+
+
+class HammerToolTestHelpers:
+    """
+    Helper functions to aid in the testing of IP library filtering/processing.
+    """
+
+    @staticmethod
+    def create_tech_dir(tech_name: str) -> Tuple[str, str]:
+        """
+        Create a temporary folder for a test technology.
+        Note: the caller is responsible for removing the tech_dir_base folder
+        after use!
+        :param tech_name: Technology name (e.g. "saed32")
+        :return: Tuple of create tech_dir and tech_dir_base (which the caller
+                 must delete)
+        """
+        tech_dir_base = tempfile.mkdtemp()
+        tech_dir = os.path.join(tech_dir_base, tech_name)
+        os.mkdir(tech_dir)
+
+        return tech_dir, tech_dir_base
+
+    @staticmethod
+    def write_tech_json(
+            tech_json_filename: str,
+            postprocessing_func: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None) -> None:
+        """
+        Write a dummy tech JSON to the given filename with the given
+        postprocessing.
+        """
+        tech_json = {
+            "name": "dummy28",
+            "installs": [
+                {
+                    "path": "test",
+                    "base var": ""  # means relative to tech dir
+                }
+            ],
+            "libraries": [
+                {"milkyway techfile": "test/soy"},
+                {"openaccess techfile": "test/juice"},
+                {"milkyway techfile": "test/coconut"},
+                {
+                    "openaccess techfile": "test/orange",
+                    "provides": [
+                        {"lib_type": "stdcell"}
+                    ]
+                },
+                {
+                    "openaccess techfile": "test/grapefruit",
+                    "provides": [
+                        {"lib_type": "stdcell"}
+                    ]
+                },
+                {
+                    "openaccess techfile": "test/tea",
+                    "provides": [
+                        {"lib_type": "technology"}
+                    ]
+                },
+            ]
+        }  # type: Dict[str, Any]
+        if postprocessing_func is not None:
+            tech_json = postprocessing_func(tech_json)
+        with open(tech_json_filename, "w") as f:  # pylint: disable=invalid-name
+            f.write(json.dumps(tech_json, indent=4))
+
+    @staticmethod
+    def make_test_filter() -> LibraryFilter:
+        """
+        Make a test filter that returns libraries with openaccess techfiles with libraries that provide 'technology'
+        in lib_type first, with the rest sorted by the openaccess techfile.
+        """
+        def filter_func(lib: hammer_tech.Library) -> bool:
+            return lib.openaccess_techfile is not None
+
+        def paths_func(lib: hammer_tech.Library) -> List[str]:
+            assert lib.openaccess_techfile is not None
+            return [lib.openaccess_techfile]
+
+        def sort_func(lib: hammer_tech.Library) -> Union[Number, str, tuple]:
+            assert lib.openaccess_techfile is not None
+            if lib.provides is not None and len(
+                    list(filter(lambda x: x is not None and x.lib_type == "technology", lib.provides))) > 0:
+                # Put technology first
+                return (0, "")
+            else:
+                return (1, str(lib.openaccess_techfile))
+
+        return LibraryFilter.new(
+            filter_func=filter_func,
+            paths_func=paths_func,
+            tag="test", description="Test filter",
+            is_file=True,
+            sort_func=sort_func
+        )


### PR DESCRIPTION
Fixes #112 and ucb-bar/hammer-cad-plugins#52

Relatively simple but enables user to have a decent amount of control.
The user can select pins and which layers/side they are placed on.
In addition pins associated with macros that should not be placed
can also be handled

There is a unit test and I also ran it on my favorite technology.