### PR TITLE
Add Site objects and use Decimal for Site and Stackup

### DIFF
--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -230,8 +230,8 @@ class Site(NamedTuple('Site', [
         """
         return Site(
             name=str(d["name"]),
-            x=coerce_to_grid(grid_unit, d["x"]),
-            y=coerce_to_grid(grid_unit, d["y"])
+            x=coerce_to_grid(d["x"], grid_unit),
+            y=coerce_to_grid(d["y"], grid_unit)
         )
 
 

--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -220,7 +220,7 @@ class Site(NamedTuple('Site', [
     __slots__ = ()
 
     @staticmethod
-    def from_setting(grid_unit: Decimal, d: dict) -> "Site":
+    def from_setting(grid_unit: Decimal, d: Dict[str, Any]) -> "Site":
         """
         Return a new Site
 

--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -213,7 +213,7 @@ class Site(NamedTuple('Site', [
     """
     A standard cell site, which is the minimum unit of x and y dimensions a standard cell can have.
 
-    name: The name of this site (usually something like "core")
+    name: The name of this site (often something like "core") as defined in the tech and standard cell LEFs
     x: The x dimension
     y: The y dimension
     """

--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -10,7 +10,7 @@ import json
 import os
 import subprocess
 from abc import ABCMeta, abstractmethod
-from typing import Any, Callable, Iterable, List, NamedTuple, Optional, Tuple
+from typing import Any, Callable, Iterable, List, NamedTuple, Optional, Tuple. Dict
 from decimal import Decimal
 
 import hammer_config

--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -10,7 +10,7 @@ import json
 import os
 import subprocess
 from abc import ABCMeta, abstractmethod
-from typing import Any, Callable, Iterable, List, NamedTuple, Optional, Tuple. Dict
+from typing import Any, Callable, Iterable, List, NamedTuple, Optional, Tuple, Dict
 from decimal import Decimal
 
 import hammer_config

--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -211,7 +211,7 @@ class Site(NamedTuple('Site', [
     ('y', Decimal)
 ])):
     """
-    A standard cell site, which is the minimum unit of x and y dimenions a standard cell can have.
+    A standard cell site, which is the minimum unit of x and y dimensions a standard cell can have.
 
     name: The name of this site (usually something like "core")
     x: The x dimension

--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -860,6 +860,9 @@ class HammerTechnology:
             raise ValueError("Tech JSON does not specify any sites")
 
     def get_placement_site(self) -> Site:
+        """
+        Return the default placement site defined by the hammer setting "vlsi.technology.placement_site"
+        """
         return self.get_site_by_name(self.get_setting("vlsi.technology.placement_site"))
 
 

--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -20,7 +20,7 @@ from hammer_config import load_yaml
 from hammer_logging import HammerVLSILoggingContext
 from hammer_utils import (LEFUtils, add_lists, deeplist, get_or_else,
                           in_place_unique, optional_map, reduce_list_str,
-                          reduce_named)
+                          reduce_named, coerce_to_grid)
 
 from library_filter import LibraryFilter
 from filters import LibraryFilterHolder

--- a/src/hammer-tech/schema.json
+++ b/src/hammer-tech/schema.json
@@ -182,6 +182,25 @@
         "additionalproperties" : false
       }
     },
+    "sites" : {
+      "type" : "array",
+      "items" : {
+        "title" : "Site",
+        "type" : "object",
+        "additionalproperties" : false,
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "x" : {
+            "type" : "number"
+          },
+          "y" : {
+            "type" : "number"
+          }
+        }
+      }
+    },
     "stackups" : {
       "type" : "array",
       "items" : {

--- a/src/hammer-tech/schema.json
+++ b/src/hammer-tech/schema.json
@@ -1,6 +1,7 @@
 {
   "title" : "TechJSON",
   "type" : "object",
+  "grid_unit" : "string",
   "properties" : {
     "installs" : {
       "type" : "array",

--- a/src/hammer-tech/schema.json
+++ b/src/hammer-tech/schema.json
@@ -1,8 +1,10 @@
 {
   "title" : "TechJSON",
   "type" : "object",
-  "grid_unit" : "string",
   "properties" : {
+    "grid_unit" : {
+      "type" : "string"
+    },
     "installs" : {
       "type" : "array",
       "items" : {

--- a/src/hammer-tech/stackup.py
+++ b/src/hammer-tech/stackup.py
@@ -110,7 +110,8 @@ class Metal(NamedTuple('Metal', [
     """
     A metal layer and some basic info about it.
 
-    grid_unit: The fixed-point decimal value of a minimum grid unit (e.g. 1nm = 0.001)
+    grid_unit: The fixed-point decimal value of a minimum grid unit (e.g. 1nm = 0.001).
+               For most technologies, this comes from the technology plugin and is the same for all layers.
     name: Metal layer name (e.g. M1, M2).
     index: The order in the stackup (lower is closer to the substrate).
     direction: The preferred routing direction of this metal layer, or
@@ -131,7 +132,7 @@ class Metal(NamedTuple('Metal', [
         """
         Return a Metal object from a dict with keys "name", "index", "direction", "min_width", "pitch", "offset", and "power_strap_widths_and_spacings"
 
-        :param grid_unit: The manufacturing grid unit in nm
+        :param grid_unit: The manufacturing grid unit in um
         :param d: A dict containing the keys "name", "index", "direction", "min_width", "pitch", "offset", and "power_strap_widths_and_spacings"
         """
         return Metal(

--- a/src/hammer-tech/stackup.py
+++ b/src/hammer-tech/stackup.py
@@ -98,20 +98,20 @@ class WidthSpacingTuple(NamedTuple('WidthSpacingTuple', [
 
 
 class Metal(NamedTuple('Metal', [
-        ('grid_unit', Decimal),
         ('name', str),
         ('index', int),
         ('direction', RoutingDirection),
         ('min_width', Decimal),
         ('pitch', Decimal),
         ('offset', Decimal),
-        ('power_strap_widths_and_spacings', List[WidthSpacingTuple])
+        ('power_strap_widths_and_spacings', List[WidthSpacingTuple]),
+        # Note: grid_unit is not currently parsed as part of the Metal data structure!
+        # See #379
+        ('grid_unit', Decimal)
 ])):
     """
     A metal layer and some basic info about it.
 
-    grid_unit: The fixed-point decimal value of a minimum grid unit (e.g. 1nm = 0.001).
-               For most technologies, this comes from the technology plugin and is the same for all layers.
     name: Metal layer name (e.g. M1, M2).
     index: The order in the stackup (lower is closer to the substrate).
     direction: The preferred routing direction of this metal layer, or
@@ -124,6 +124,8 @@ class Metal(NamedTuple('Metal', [
             (0 = first track is on an axis).
     power_strap_widths_and_spacings: A list of WidthSpacingTuples that specify the minimum
                                      spacing rules for an infinitely long wire of variying width.
+    grid_unit: The fixed-point decimal value of a minimum grid unit (e.g. 1nm = 0.001).
+               For most technologies, this comes from the technology plugin and is the same for all layers.
     """
     __slots__ = ()
 

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -434,15 +434,7 @@ par:
   # If power_straps_mode is 'generate', which method to use.
   # Currently, the valid options are:
   # - by_tracks - Specify the power strap plan per layer in terms of tracks
-  # - by_tracks_hier - Only valid for hierarchical blocks- uses the top-level by_tracks to determine parameters
   generate_power_straps_method: "by_tracks"
-
-  # Default settings for power strap generation modes
-  # Keys are the valid values of the 'generate_power_straps_method' key above
-  generate_power_straps_options:
-    by_tracks_hier:
-      # Layers to put power pins on (this is currently the only overrideable API)
-      pin_layers: []
 
     by_tracks:
       # Spacing from end of strap to a block or blockage

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -434,11 +434,16 @@ par:
   # If power_straps_mode is 'generate', which method to use.
   # Currently, the valid options are:
   # - by_tracks - Specify the power strap plan per layer in terms of tracks
+  # - by_tracks_hier - Only valid for hierarchical blocks- uses the top-level by_tracks to determine parameters
   generate_power_straps_method: "by_tracks"
 
   # Default settings for power strap generation modes
   # Keys are the valid values of the 'generate_power_straps_method' key above
   generate_power_straps_options:
+    by_tracks_hier:
+      # Layers to put power pins on (this is currently the only overrideable API)
+      pin_layers: []
+
     by_tracks:
       # Spacing from end of strap to a block or blockage
       # Overrideable by appending _<layer name>
@@ -449,6 +454,11 @@ par:
       # Overrideable by appending _<layer name>
       track_width: 5
 
+      # The first track to contain a power stripe
+      # Overrideable by appending _<layer name>
+      # TODO(johnwright) include an auto-center option
+      track_start: 0
+
       # Number of routing tracks between sets of straps (0 is recommended)
       # Overrideable by appending _<layer name>
       track_spacing: 0
@@ -456,6 +466,9 @@ par:
       # Ratio of total routing tracks to dedicate to power straps, which is used to calculate set pitch
       # Overrideable by appending _<layer name>
       power_utilization: 0.1
+
+      # Layers to put power pins on
+      pin_layers: []
 
       # List of layers on which to place power straps (std cell rail layer is implied- do not include it)
       # Not overrideable

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -436,6 +436,9 @@ par:
   # - by_tracks - Specify the power strap plan per layer in terms of tracks
   generate_power_straps_method: "by_tracks"
 
+  # Default settings for power strap generation modes
+  # Keys are the valid values of the 'generate_power_straps_method' key above
+  generate_power_straps_options:
     by_tracks:
       # Spacing from end of strap to a block or blockage
       # Overrideable by appending _<layer name>

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -456,7 +456,7 @@ par:
 
       # The first track to contain a power stripe
       # Overrideable by appending _<layer name>
-      # TODO(johnwright) include an auto-center option
+      # TODO(johnwright): include an auto-center option
       track_start: 0
 
       # Number of routing tracks between sets of straps (0 is recommended)

--- a/src/hammer-vlsi/hammer_utils/__init__.py
+++ b/src/hammer-vlsi/hammer_utils/__init__.py
@@ -8,7 +8,7 @@
 import copy
 import inspect
 from functools import reduce
-from typing import List, Any, Set, Dict, Tuple, TypeVar, Callable, Iterable, Optional
+from typing import List, Any, Set, Dict, Tuple, TypeVar, Callable, Iterable, Optional, Union
 from enum import Enum, unique
 from decimal import Decimal
 
@@ -107,7 +107,7 @@ def coerce_to_grid(num: float, grid: Decimal) -> Decimal:
     """
     return Decimal(round(num / float(grid))) * grid
 
-def check_on_grid(num: Union[float, Decimal], grid: Decimal) -> Decimal:
+def check_on_grid(num: Union[float, Decimal], grid: Decimal) -> bool:
     """
     Checks if a number is an integer multiple of a specified grid unit.
     This supports floats and Decimals, although support for floats will eventually be removed.
@@ -118,9 +118,9 @@ def check_on_grid(num: Union[float, Decimal], grid: Decimal) -> Decimal:
     :return: True if num is on-grid, False otherwise
     """
     # TODO(johnwright) Remove float support in ucb-bar/hammer#376
-    num_dec = num if isinstance(num, Decimal) else coerce_to_grid(num)
+    num_dec = num if isinstance(num, Decimal) else coerce_to_grid(num, Decimal("0.001"))
     assert isinstance(num_dec, Decimal)
-    return Decimal(int(num / grid)) == (num / grid)
+    return Decimal(int(num_dec / grid)) == (num_dec / grid)
 
 def gcd(*values: int) -> int:
     """

--- a/src/hammer-vlsi/hammer_utils/__init__.py
+++ b/src/hammer-vlsi/hammer_utils/__init__.py
@@ -10,14 +10,10 @@ import inspect
 from functools import reduce
 from typing import List, Any, Set, Dict, Tuple, TypeVar, Callable, Iterable, Optional
 from enum import Enum, unique
+from decimal import Decimal
 
 from .verilog_utils import *
 from .lef_utils import *
-
-__all__ = ['VerilogUtils', 'LEFUtils',
-           'deepdict', 'deeplist', 'add_lists', 'add_dicts', 'reverse_dict', 'in_place_unique', 'topological_sort',
-           'reduce_named', 'reduce_list_str', 'get_or_else', 'optional_map', 'assert_function_type',
-           'check_function_type']
 
 
 def deepdict(x: dict) -> dict:
@@ -99,6 +95,10 @@ def in_place_unique(items: List[Any]) -> None:
         else:
             seen.add(item)
             i += 1
+
+
+def coerce_to_grid(num: float, grid: Decimal) -> Decimal:
+    return Decimal(round(num / float(grid))) * grid
 
 
 def topological_sort(graph: Dict[str, Tuple[List[str], List[str]]], starting_nodes: List[str]) -> List[str]:

--- a/src/hammer-vlsi/hammer_utils/__init__.py
+++ b/src/hammer-vlsi/hammer_utils/__init__.py
@@ -7,6 +7,7 @@
 
 import copy
 import inspect
+import math
 from functools import reduce
 from typing import List, Any, Set, Dict, Tuple, TypeVar, Callable, Iterable, Optional, Union
 from enum import Enum, unique
@@ -130,16 +131,7 @@ def gcd(*values: int) -> int:
     :return: The GCD
     """
     assert len(values) > 0
-    if len(values) == 1:
-        return values[0]
-    elif len(values) == 2:
-        a = values[0]
-        b = values[1]
-        while b > 0:
-            a, b =  b, a % b
-        return a
-    else:
-        return gcd(values[0], gcd(*values[1:]))
+    return reduce(math.gcd, values)
 
 def lcm(*values: int) -> int:
     """
@@ -149,12 +141,7 @@ def lcm(*values: int) -> int:
     :return: The LCM
     """
     assert len(values) > 0
-    if len(values) == 1:
-        return values[0]
-    elif len(values) == 2:
-        return int((values[0] * values[1]) / gcd(*values))
-    else:
-        return lcm(values[0], lcm(*values[1:]))
+    return reduce(lambda x, y: (x * y) // math.gcd(x, y), values)
 
 def lcm_grid(grid: Decimal, *values: Decimal) -> Decimal:
     """
@@ -164,7 +151,7 @@ def lcm_grid(grid: Decimal, *values: Decimal) -> Decimal:
     :param values: The values of which to compute the LCM
     :return: The LCM
     """
-    return grid * lcm(*map(lambda x: int(x/grid), values))
+    return grid * lcm(*map(lambda x: int(x / grid), values))
 
 def topological_sort(graph: Dict[str, Tuple[List[str], List[str]]], starting_nodes: List[str]) -> List[str]:
     """

--- a/src/hammer-vlsi/hammer_utils/__init__.py
+++ b/src/hammer-vlsi/hammer_utils/__init__.py
@@ -101,6 +101,50 @@ def coerce_to_grid(num: float, grid: Decimal) -> Decimal:
     return Decimal(round(num / float(grid))) * grid
 
 
+def gcd(*values: int) -> int:
+    """
+    Return the greatest common divisor of a series of ints
+
+    :param values: The values of which to compute the GCD
+    :return: The GCD
+    """
+    assert len(values) > 0
+    if len(values) == 1:
+        return values[0]
+    elif len(values) == 2:
+        a = values[0]
+        b = values[1]
+        while b > 0:
+            a, b =  b, a % b
+        return a
+    else:
+        return gcd(values[0], gcd(*values[1:]))
+
+def lcm(*values: int) -> int:
+    """
+    Return the least common multiple of a series of ints
+
+    :param values: The values of which to compute the LCM
+    :return: The LCM
+    """
+    assert len(values) > 0
+    if len(values) == 1:
+        return values[0]
+    elif len(values) == 2:
+        return int((values[0] * values[1]) / gcd(*values))
+    else:
+        return lcm(values[0], lcm(*values[1:]))
+
+def lcm_grid(grid: Decimal, *values: Decimal) -> Decimal:
+    """
+    Return the least common multiple of a series of decimal values on a provided grid
+
+    :param grid: The unit grid
+    :param values: The values of which to compute the LCM
+    :return: The LCM
+    """
+    return grid * lcm(*map(lambda x: int(x/grid), values))
+
 def topological_sort(graph: Dict[str, Tuple[List[str], List[str]]], starting_nodes: List[str]) -> List[str]:
     """
     Perform a topological sort on the graph and return a valid ordering.

--- a/src/hammer-vlsi/hammer_utils/__init__.py
+++ b/src/hammer-vlsi/hammer_utils/__init__.py
@@ -136,7 +136,8 @@ def gcd(*values: int) -> int:
     if sys.version_info.major == 3 and sys.version_info.minor < 5:
         import fractional
         return reduce(fractional.gcd, values)
-    return reduce(math.gcd, values)
+    else:
+        return reduce(math.gcd, values)
 
 def lcm(*values: int) -> int:
     """
@@ -150,7 +151,8 @@ def lcm(*values: int) -> int:
     if sys.version_info.major == 3 and sys.version_info.minor < 5:
         import fractional
         return reduce(lambda x, y: (x * y) // fractional.gcd(x, y), values)
-    return reduce(lambda x, y: (x * y) // math.gcd(x, y), values)
+    else:
+        return reduce(lambda x, y: (x * y) // math.gcd(x, y), values)
 
 def lcm_grid(grid: Decimal, *values: Decimal) -> Decimal:
     """

--- a/src/hammer-vlsi/hammer_utils/__init__.py
+++ b/src/hammer-vlsi/hammer_utils/__init__.py
@@ -132,10 +132,10 @@ def gcd(*values: int) -> int:
     :return: The GCD
     """
     assert len(values) > 0
-    # 3.5 moves fractional.gcd to math.gcd
+    # 3.5 moves fractions.gcd to math.gcd
     if sys.version_info.major == 3 and sys.version_info.minor < 5:
-        import fractional
-        return reduce(fractional.gcd, values)
+        import fractions
+        return reduce(fractions.gcd, values)
     else:
         return reduce(math.gcd, values)
 
@@ -147,10 +147,10 @@ def lcm(*values: int) -> int:
     :return: The LCM
     """
     assert len(values) > 0
-    # 3.5 moves fractional.gcd to math.gcd
+    # 3.5 moves fractions.gcd to math.gcd
     if sys.version_info.major == 3 and sys.version_info.minor < 5:
-        import fractional
-        return reduce(lambda x, y: (x * y) // fractional.gcd(x, y), values)
+        import fractions
+        return reduce(lambda x, y: (x * y) // fractions.gcd(x, y), values)
     else:
         return reduce(lambda x, y: (x * y) // math.gcd(x, y), values)
 

--- a/src/hammer-vlsi/hammer_utils/__init__.py
+++ b/src/hammer-vlsi/hammer_utils/__init__.py
@@ -8,6 +8,7 @@
 import copy
 import inspect
 import math
+import sys
 from functools import reduce
 from typing import List, Any, Set, Dict, Tuple, TypeVar, Callable, Iterable, Optional, Union
 from enum import Enum, unique
@@ -131,7 +132,6 @@ def gcd(*values: int) -> int:
     :return: The GCD
     """
     assert len(values) > 0
-    import sys
     # 3.5 moves fractional.gcd to math.gcd
     if sys.version_info.major == 3 and sys.version_info.minor < 5:
         import fractional
@@ -297,7 +297,6 @@ def check_function_type(function: Callable, args: List[type], return_type: type)
         """Return true if 't' is a Union type."""
         import typing
         if not hasattr(t, "__origin__"):
-            import sys
             if sys.version_info.major == 3 and sys.version_info.minor == 5 and sys.version_info.micro <= 2:
                 # Python compatibility: <3.5.2
 

--- a/src/hammer-vlsi/hammer_utils/__init__.py
+++ b/src/hammer-vlsi/hammer_utils/__init__.py
@@ -107,6 +107,20 @@ def coerce_to_grid(num: float, grid: Decimal) -> Decimal:
     """
     return Decimal(round(num / float(grid))) * grid
 
+def check_on_grid(num: Union[float, Decimal], grid: Decimal) -> Decimal:
+    """
+    Checks if a number is an integer multiple of a specified grid unit.
+    This supports floats and Decimals, although support for floats will eventually be removed.
+    Removal of float support will be in ucb-bar/hammer#376
+
+    :param num: The number to check
+    :param grid: The decimal grid value on which to check number
+    :return: True if num is on-grid, False otherwise
+    """
+    # TODO(johnwright) Remove float support in ucb-bar/hammer#376
+    num_dec = num if isinstance(num, Decimal) else coerce_to_grid(num)
+    assert isinstance(num_dec, Decimal)
+    return Decimal(int(num / grid)) == (num / grid)
 
 def gcd(*values: int) -> int:
     """

--- a/src/hammer-vlsi/hammer_utils/__init__.py
+++ b/src/hammer-vlsi/hammer_utils/__init__.py
@@ -131,6 +131,11 @@ def gcd(*values: int) -> int:
     :return: The GCD
     """
     assert len(values) > 0
+    import sys
+    # 3.5 moves fractional.gcd to math.gcd
+    if sys.version_info.major == 3 and sys.version_info.minor < 5:
+        import fractional
+        return reduce(fractional.gcd, values)
     return reduce(math.gcd, values)
 
 def lcm(*values: int) -> int:
@@ -141,6 +146,10 @@ def lcm(*values: int) -> int:
     :return: The LCM
     """
     assert len(values) > 0
+    # 3.5 moves fractional.gcd to math.gcd
+    if sys.version_info.major == 3 and sys.version_info.minor < 5:
+        import fractional
+        return reduce(lambda x, y: (x * y) // fractional.gcd(x, y), values)
     return reduce(lambda x, y: (x * y) // math.gcd(x, y), values)
 
 def lcm_grid(grid: Decimal, *values: Decimal) -> Decimal:

--- a/src/hammer-vlsi/hammer_utils/__init__.py
+++ b/src/hammer-vlsi/hammer_utils/__init__.py
@@ -98,6 +98,13 @@ def in_place_unique(items: List[Any]) -> None:
 
 
 def coerce_to_grid(num: float, grid: Decimal) -> Decimal:
+    """
+    Coerce a floating-point number to the nearest multiple of the provided grid
+
+    :param num: The input floating-point number
+    :param grid: The decimal grid value to which num should be coerced
+    :return: A decimal number on-grid
+    """
     return Decimal(round(num / float(grid))) * grid
 
 

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, ca
 import hammer_config
 import hammer_tech
 from hammer_logging import HammerVLSILoggingContext
-from hammer_tech import LibraryFilter, Stackup, RoutingDirection
+from hammer_tech import LibraryFilter, Stackup, RoutingDirection, Metal
 from hammer_utils import (add_lists, assert_function_type, get_or_else,
                           optional_map)
 

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -960,6 +960,23 @@ class HammerTool(metaclass=ABCMeta):
             assigns.append(PinAssignment(pins=pins, side=side, layers=layers, preplaced=preplaced))
         return assigns
 
+    def get_pin_metals(self) -> List[Metal]:
+        """
+        Get a list of the layer objects used by the current block's pins.
+        Returns an empty list if there are no pins or if the hammer pin API is not used.
+
+        :return: A potentially empty list of Metal objects
+        """
+        # This could probably be written more functional-y but this works for now.
+        metals = []  # type: List[Metal]
+        for raw_assign in self.get_setting("vlsi.inputs.pin.assignments"):
+            layers = [] if not "layers" in raw_assign else raw_assign["layers"]
+            for layer in layers:
+                metal = self.get_stackup().get_metal(layer)
+                if metal not in metals:
+                    metals.append(metal)
+        return metals
+
     def get_gds_map_file(self) -> Optional[str]:
         """
         Get a GDS map in accordance with settings in the Hammer IR.

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -960,23 +960,6 @@ class HammerTool(metaclass=ABCMeta):
             assigns.append(PinAssignment(pins=pins, side=side, layers=layers, preplaced=preplaced))
         return assigns
 
-    def get_pin_metals(self) -> List[Metal]:
-        """
-        Get a list of the layer objects used by the current block's pins.
-        Returns an empty list if there are no pins or if the hammer pin API is not used.
-
-        :return: A potentially empty list of Metal objects
-        """
-        # This could probably be written more functional-y but this works for now.
-        metals = []  # type: List[Metal]
-        for raw_assign in self.get_setting("vlsi.inputs.pin.assignments"):
-            layers = [] if not "layers" in raw_assign else raw_assign["layers"]
-            for layer in layers:
-                metal = self.get_stackup().get_metal(layer)
-                if metal not in metals:
-                    metals.append(metal)
-        return metals
-
     def get_gds_map_file(self) -> Optional[str]:
         """
         Get a GDS map in accordance with settings in the Hammer IR.

--- a/src/hammer-vlsi/tech_test.py
+++ b/src/hammer-vlsi/tech_test.py
@@ -18,6 +18,7 @@ from hammer_logging import HammerVLSILogging
 import hammer_tech
 from hammer_tech import LibraryFilter, Stackup, Metal, WidthSpacingTuple
 from hammer_utils import deepdict
+from decimal import Decimal
 
 
 class HammerTechnologyTest(HasGetTech, unittest.TestCase):
@@ -527,27 +528,22 @@ END LIBRARY
 
 class StackupTestHelper:
 
-    # TODO when the manufacturing grid concept exists, update this
     @staticmethod
-    def mfr_grid() -> float:
-        return 0.001
-
-    @staticmethod
-    def snap(f: float) -> float:
-        return float(round(f / StackupTestHelper.mfr_grid())) * StackupTestHelper.mfr_grid()
+    def mfr_grid() -> Decimal:
+        return Decimal("0.001")
 
     @staticmethod
     def index_to_min_width_fn(index: int) -> float:
         assert index > 0
-        return StackupTestHelper.snap(0.05 * (1 if (index < 3) else (2 if (index < 5) else 5)))
+        return 0.05 * (1 if (index < 3) else (2 if (index < 5) else 5))
 
     @staticmethod
     def index_to_min_pitch_fn(index: int) -> float:
-        return StackupTestHelper.snap((StackupTestHelper.index_to_min_width_fn(index) * 9.0) / 5.0)
+        return (StackupTestHelper.index_to_min_width_fn(index) * 9) / 5
 
     @staticmethod
     def index_to_offset_fn(index: int) -> float:
-        return StackupTestHelper.snap(0.04)
+        return 0.04
 
     @staticmethod
     def create_wst_list(index: int) -> List[Dict[str, float]]:
@@ -555,8 +551,8 @@ class StackupTestHelper:
         base_s = StackupTestHelper.index_to_min_pitch_fn(index) - base_w
         wst = []
         for x in range(5):
-            wst.append({"width_at_least": StackupTestHelper.snap(float(x) * base_w * 3),
-                        "min_spacing": StackupTestHelper.snap(float(x+1) * base_s) })
+            wst.append({"width_at_least": x * base_w * 3,
+                        "min_spacing": (x+1) * base_s})
         return wst
 
     @staticmethod
@@ -584,7 +580,7 @@ class StackupTestHelper:
     def create_test_stackup_list() -> List["Stackup"]:
         output = []
         for x in range(5,8):
-            output.append(Stackup.from_setting(StackupTestHelper.create_test_stackup_dict(x)))
+            output.append(Stackup.from_setting(StackupTestHelper.mfr_grid(), StackupTestHelper.create_test_stackup_dict(x)))
             for m in output[-1].metals:
                 assert m.grid_unit == StackupTestHelper.mfr_grid(), "FIXME: the unit grid is different between the tests and metals"
         return output
@@ -605,7 +601,7 @@ class StackupTest(unittest.TestCase):
             # Try with 1 track (this should return a minimum width wire)
             w, s, o = m.get_width_spacing_start_twt(1)
             self.assertEqual(w, m.min_width)
-            self.assertEqual(s, m.snap(m.pitch - w))
+            self.assertEqual(s, m.pitch - w)
 
             # e.g. 2 tracks:
             # | | | |
@@ -618,11 +614,11 @@ class StackupTest(unittest.TestCase):
                 # Check that the resulting spacing is the min spacing
                 self.assertTrue(s >= m.get_spacing_for_width(w))
                 # Check that there is no DRC
-                self.assertGreaterEqual(m.snap(m.pitch * (num_tracks + 1)), m.snap(m.min_width + s*2 + w))
+                self.assertGreaterEqual(m.pitch * (num_tracks + 1), m.min_width + s*2 + w)
                 # Check that if we increase the width slightly we get a DRC violation
-                w = m.snap(w + (m.grid_unit*2))
+                w = w + (m.grid_unit * 2)
                 s = m.get_spacing_for_width(w)
-                self.assertLess(m.snap(m.pitch * (num_tracks + 1)), m.snap(m.min_width + s*2 + w))
+                self.assertLess(m.pitch * (num_tracks + 1), m.min_width + s*2 + w)
 
     # Test that a T W W T wire is correctly sized
     # This will pass if the wide wire does not have a spacing DRC violation to surrounding minimum-sized wires and is within a single unit grid
@@ -634,7 +630,7 @@ class StackupTest(unittest.TestCase):
             # Try with 1 track (this should return a minimum width wire)
             w, s, o = m.get_width_spacing_start_twwt(1)
             self.assertEqual(w, m.min_width)
-            self.assertEqual(s, m.snap(m.pitch - w))
+            self.assertEqual(s, m.pitch - w)
 
             # e.g. 2 tracks:
             # | | | | | |
@@ -647,11 +643,11 @@ class StackupTest(unittest.TestCase):
                 # Check that the resulting spacing is the min spacing
                 self.assertGreaterEqual(s, m.get_spacing_for_width(w))
                 # Check that there is no DRC
-                self.assertGreaterEqual(m.snap(m.pitch * (2*num_tracks + 1)), m.snap(m.min_width + s*3 + w*2))
+                self.assertGreaterEqual(m.pitch * (2 * num_tracks + 1), m.min_width + s*3 + w*2)
                 # Check that if we increase the width slightly we get a DRC violation
                 w = w + (m.grid_unit*2)
                 s = m.get_spacing_for_width(w)
-                self.assertLess(m.snap(m.pitch * (2*num_tracks + 1)), m.snap(m.min_width + s*3 + w*2))
+                self.assertLess(m.pitch * (2 * num_tracks + 1), m.min_width + s*3 + w*2)
 
 
     def test_min_spacing_for_width(self) -> None:
@@ -659,9 +655,9 @@ class StackupTest(unittest.TestCase):
         stackup = StackupTestHelper.create_test_stackup_list()[-1]
         for m in stackup.metals:
             # generate some widths:
-            for x in [1.0, 2.0, 3.4, 4.5, 5.25, 50.2]:
+            for x in ["1.0", "2.0", "3.4", "4.5", "5.25", "50.2"]:
                 # coerce to a manufacturing grid, this is just a test data point
-                w = m.snap(x * m.min_width)
+                w = Decimal(x) * m.min_width
                 s = m.get_spacing_for_width(w)
                 for wst in m.power_strap_widths_and_spacings:
                     if w >= wst.width_at_least:
@@ -674,14 +670,14 @@ class StackupTest(unittest.TestCase):
             # generate some widths:
             for x in range(0, 100000, 5):
                 # Generate a test data point
-                p = m.snap((m.grid_unit * x) + m.pitch)
+                p = (m.grid_unit * x) + m.pitch
                 s = m.min_spacing_from_pitch(p)
-                w = m.snap(p - s)
+                w = p - s
                 # Check that we don't violate DRC
-                self.assertGreaterEqual(p, m.snap(w + m.get_spacing_for_width(w)))
+                self.assertGreaterEqual(p, w + m.get_spacing_for_width(w))
                 # Check that the wire is as large as possible by growing it
-                w = m.snap(w + (m.grid_unit*2))
-                self.assertLess(p, m.snap(w + m.get_spacing_for_width(w)))
+                w = w + (m.grid_unit*2)
+                self.assertLess(p, w + m.get_spacing_for_width(w))
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/hammer-vlsi/test_tool_utils.py
+++ b/src/hammer-vlsi/test_tool_utils.py
@@ -75,6 +75,7 @@ class HammerToolTestHelpers:
         """
         tech_json = {
             "name": "dummy28",
+            "grid_unit": "0.001",
             "installs": [
                 {
                     "path": "test",

--- a/src/hammer-vlsi/utils_test.py
+++ b/src/hammer-vlsi/utils_test.py
@@ -54,6 +54,7 @@ class UtilsTest(unittest.TestCase):
     def test_coerce_to_grid(self) -> None:
         self.assertEqual(coerce_to_grid(1.23, Decimal("0.1")), Decimal("1.2"))
         self.assertEqual(coerce_to_grid(1.23, Decimal("0.01")), Decimal("1.23"))
+        self.assertEqual(coerce_to_grid(1.227, Decimal("0.01")), Decimal("1.23"))
         self.assertEqual(coerce_to_grid(200, Decimal("10")), Decimal("200"))
 
     def test_check_on_grid(self) -> None:

--- a/src/hammer-vlsi/utils_test.py
+++ b/src/hammer-vlsi/utils_test.py
@@ -9,7 +9,7 @@ from typing import Dict, Tuple, List, Optional, Union
 from decimal import Decimal
 
 from hammer_utils import (topological_sort, get_or_else, optional_map, assert_function_type,
-                          gcd, lcm, lcm_grid)
+                          gcd, lcm, lcm_grid, coerce_to_grid, check_on_grid)
 
 import unittest
 
@@ -54,7 +54,7 @@ class UtilsTest(unittest.TestCase):
     def test_coerce_to_grid(self) -> None:
         self.assertEqual(coerce_to_grid(1.23, Decimal("0.1")), Decimal("1.2"))
         self.assertEqual(coerce_to_grid(1.23, Decimal("0.01")), Decimal("1.23"))
-        self.assertEqual(coerce_to_grid(200, Decimal("10"), Decimal("200"))
+        self.assertEqual(coerce_to_grid(200, Decimal("10")), Decimal("200"))
 
     def test_check_on_grid(self) -> None:
         self.assertTrue(check_on_grid(Decimal("1.23"), Decimal("0.01")))

--- a/src/hammer-vlsi/utils_test.py
+++ b/src/hammer-vlsi/utils_test.py
@@ -56,6 +56,7 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual(coerce_to_grid(1.23, Decimal("0.01")), Decimal("1.23"))
         self.assertEqual(coerce_to_grid(1.227, Decimal("0.01")), Decimal("1.23"))
         self.assertEqual(coerce_to_grid(200, Decimal("10")), Decimal("200"))
+        self.assertEqual(coerce_to_grid(1.0/3.0, Decimal("0.001")), Decimal("0.333"))
 
     def test_check_on_grid(self) -> None:
         self.assertTrue(check_on_grid(Decimal("1.23"), Decimal("0.01")))

--- a/src/hammer-vlsi/utils_test.py
+++ b/src/hammer-vlsi/utils_test.py
@@ -51,6 +51,20 @@ class UtilsTest(unittest.TestCase):
         self.assertNotEqual(optional_map("88", str_to_num), "880")
         self.assertEqual(optional_map("42", str_to_num), 420)
 
+    def test_coerce_to_grid(self) -> None:
+        self.assertEqual(coerce_to_grid(1.23, Decimal("0.1")), Decimal("1.2"))
+        self.assertEqual(coerce_to_grid(1.23, Decimal("0.01")), Decimal("1.23"))
+        self.assertEqual(coerce_to_grid(200, Decimal("10"), Decimal("200"))
+
+    def test_check_on_grid(self) -> None:
+        self.assertTrue(check_on_grid(Decimal("1.23"), Decimal("0.01")))
+        self.assertFalse(check_on_grid(Decimal("1.23"), Decimal("0.1")))
+        self.assertTrue(check_on_grid(Decimal("1.20"), Decimal("0.1")))
+        self.assertTrue(check_on_grid(Decimal("1.20"), Decimal("0.03")))
+        self.assertFalse(check_on_grid(Decimal("1.20"), Decimal("0.07")))
+        self.assertTrue(check_on_grid(Decimal("2000"), Decimal("10")))
+        self.assertFalse(check_on_grid(Decimal("2000"), Decimal("13")))
+
     def test_gcd(self) -> None:
         self.assertEqual(gcd(1,2,3), 1)
         self.assertEqual(gcd(4,6,8), 2)

--- a/src/hammer-vlsi/utils_test.py
+++ b/src/hammer-vlsi/utils_test.py
@@ -6,8 +6,10 @@
 #  See LICENSE for licence details.
 
 from typing import Dict, Tuple, List, Optional, Union
+from decimal import Decimal
 
-from hammer_utils import topological_sort, get_or_else, optional_map, assert_function_type
+from hammer_utils import (topological_sort, get_or_else, optional_map, assert_function_type,
+                          gcd, lcm, lcm_grid)
 
 import unittest
 
@@ -48,6 +50,29 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual(optional_map("88", str_to_num), 880)
         self.assertNotEqual(optional_map("88", str_to_num), "880")
         self.assertEqual(optional_map("42", str_to_num), 420)
+
+    def test_gcd(self) -> None:
+        self.assertEqual(gcd(1,2,3), 1)
+        self.assertEqual(gcd(4,6,8), 2)
+        self.assertEqual(gcd(3,6), 3)
+        self.assertEqual(gcd(17), 17)
+        self.assertEqual(gcd(1033, 1999), 1)
+        self.assertEqual(gcd(1024, 4096), 1024)
+
+    def test_lcm(self) -> None:
+        self.assertEqual(lcm(1,2,3), 6)
+        self.assertEqual(lcm(4,6,8), 24)
+        self.assertEqual(lcm(3,6), 6)
+        self.assertEqual(lcm(17), 17)
+        self.assertEqual(lcm(1033, 1999), 2064967)
+        self.assertEqual(lcm(1024, 4096), 4096)
+
+    def test_lcm_grid(self) -> None:
+        unit = Decimal("0.001")
+        self.assertEqual(lcm_grid(unit, Decimal("1.234")), Decimal("1.234"))
+        self.assertEqual(lcm_grid(unit, Decimal("0.09"), Decimal("0.08")), Decimal("0.72"))
+        self.assertEqual(lcm_grid(unit, Decimal("0.003"), Decimal("0.005"), Decimal("0.11")), Decimal("0.33"))
+        self.assertEqual(lcm_grid(unit, Decimal("0.245"), Decimal("0.013"), Decimal("0.002")), Decimal("6.37"))
 
     def test_check_function_type(self) -> None:
         def test1(x: int) -> str:


### PR DESCRIPTION
Fixes #319. This adds site objects which will be used for hierarchical floorplanning checks in ucb-bar/hammer-cad-plugins#91

This will also finally switch the coordinate system over to integer multiples of the manufacturing grid instead of dealing with floats and rounding everywhere.