### PR TITLE
Add some assertions to sanity check the tech plugin

### DIFF
--- a/src/hammer-tech/stackup.py
+++ b/src/hammer-tech/stackup.py
@@ -279,6 +279,7 @@ class Metal(NamedTuple('Metal', [
         """
         widths_and_spacings = self.power_strap_widths_and_spacings
         spacing = widths_and_spacings[0].min_spacing
+        assert self.pitch - self.min_width == spacing, "Tech plugin is malformed for metal {}, the minimum spacing in the width-spacing list must be the same as (pitch - min_width).".format(self.name)
         # the T W W T pattern contains two wires (W2) and 3 spaces (S3)
         s3w2 = ((2 * tracks) + 1) * self.pitch - self.min_width
         width = (s3w2 - spacing * 3) / 2

--- a/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py
@@ -528,6 +528,8 @@ class HammerPlaceAndRouteTool(HammerTool):
             width, spacing, strap_start = layer.get_width_spacing_start_twt(track_width)
             spacing = 2*spacing + (track_spacing - 1) * layer.pitch + layer.min_width
         offset = track_offset + track_start * layer.pitch + strap_start
+        assert width > Decimal(0), "Width must be greater than zero. You probably have a malformed tech plugin on layer {}.".format(layer_name)
+        assert spacing > Decimal(0), "Spacing must be greater than zero. You probably have a malformed tech plugin on layer {}.".format(layer_name)
         return self.specify_power_straps(layer_name, bottom_via_layer, blockage_spacing, pitch, width, spacing, offset, bbox, nets, add_pins)
 
     def specify_all_power_straps_by_tracks(self, layer_names: List[str], ground_net: str, power_nets: List[str], power_weights: List[int], bbox: Optional[List[Decimal]], pin_layers: List[str]) -> List[str]:


### PR DESCRIPTION
We ran into issues with a malformed tech plugin that silently generated nonsensical power straps. Also funnily enough, our place and route tool of choice does NOT error out when you specify a negative power strap width...

