### PR TITLE
Mode enum

### DIFF
--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -437,10 +437,10 @@ par:
 
   # Power straps configuration.
   # Valid options are:
-  # - blank - Specify no power straps
+  # - empty - Specify no power straps
   # - manual - Specify the contents of a manual TCL script to use, specified in power_straps_script_contents.
   # - generate - Generate power straps from Hammer IR.
-  power_straps_mode: blank
+  power_straps_mode: empty
   power_straps_script_contents: null
 
   # Spacing around blocks and hardmacros in microns

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -28,6 +28,9 @@ from .hooks import (HammerStepFunction, HammerToolHookAction, HammerToolStep,
 from .submit_command import HammerSubmitCommand
 from .units import TemperatureValue, TimeValue, VoltageValue
 
+from enum import Enum
+from hammer_utils import reverse_dict
+
 __all__ = ['HammerTool']
 
 
@@ -1128,3 +1131,34 @@ class HammerTool(metaclass=ABCMeta):
         """
         output_buffer.append("""puts "{0}" """.format(cmd.replace('"', '\"')))
         output_buffer.append(cmd)
+class ModeType(Enum):
+    Auto = 1
+    Empty = 2
+    Manual = 3
+    Generate = 4
+    Generated = 5
+    Append = 6
+    Prepend = 7
+
+    @classmethod
+    def __mapping(cls) -> Dict[str, "ModeType"]:
+        return {
+            "auto": ModeType.Auto,
+            "empty": ModeType.Empty,
+            "manual": ModeType.Manual,
+            "generate": ModeType.Generated,
+            "generated": ModeType.Generate,
+            "append": ModeType.Append,
+            "prepend": ModeType.Prepend
+        }
+
+    @staticmethod
+    def from_str(input_str: str) -> "ModeType":
+        try:
+            return ModeType.__mapping()[input_str]
+        except KeyError:
+            raise ValueError("Invalid mode type: " + str(input_str))
+
+    def __str__(self) -> str:
+        return reverse_dict(ModeType.__mapping())[self]
+


### PR DESCRIPTION
Issue: https://github.com/ucb-bar/hammer/issues/400
I was not entirely sure where to put the mode enum class so I put it in hammer_tool.py. I can move it if there is a better place to put it.