### PR TITLE
Don't crash on checking untyped arguments

### DIFF
--- a/src/hammer-vlsi/hammer_utils/__init__.py
+++ b/src/hammer-vlsi/hammer_utils/__init__.py
@@ -364,7 +364,7 @@ def check_function_type(function: Callable, args: List[type], return_type: type)
             "Too many arguments - got {got}, expected {expected}".format(got=len(inspected_args), expected=len(args)))
     else:
         for i, (inspected_var_name, expected) in list(enumerate(zip(inspected_args, args))):
-            inspected = annotations[inspected_var_name]
+            inspected = annotations.get(inspected_var_name, None)
             if not compare_types(inspected, expected):
                 inspected_name = get_name_from_type(inspected)
                 expected_name = get_name_from_type(expected)

--- a/src/hammer-vlsi/utils_test.py
+++ b/src/hammer-vlsi/utils_test.py
@@ -8,7 +8,7 @@
 from typing import Dict, Tuple, List, Optional, Union
 from decimal import Decimal
 
-from hammer_utils import (topological_sort, get_or_else, optional_map, assert_function_type,
+from hammer_utils import (topological_sort, get_or_else, optional_map, assert_function_type, check_function_type,
                           gcd, lcm, lcm_grid, coerce_to_grid, check_on_grid)
 
 import unittest
@@ -137,6 +137,14 @@ class UtilsTest(unittest.TestCase):
         assert_function_type(test8, ["int"], list)  # type: ignore
         assert_function_type(test8, [int], "list")  # type: ignore
         assert_function_type(test8, [int], list)
+
+        # Check that untyped arguments don't crash.
+        def test9(x) -> str:
+            return str(x)
+
+        test9_return = check_function_type(test9, [int], str)
+        assert test9_return is not None
+        self.assertTrue("incorrect signature" in test9_return)
 
         with self.assertRaises(TypeError):
             # Different # of arguments


### PR DESCRIPTION
This fixes a crash that can happen if `check_function_type` is used on an untyped argument. It has no functional change to the code at large.