### PR TITLE
Floorplan Constraints Overhaul. Fixes #113 and #376

### DIFF
--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -241,8 +241,8 @@ class Site(NamedTuple('Site', [
 class MacroSize(NamedTuple('MacroSize', [
     ('library', str),
     ('name', str),
-    ('width', float),
-    ('height', float)
+    ('width', Decimal),
+    ('height', Decimal)
 ])):
     __slots__ = ()
 
@@ -259,8 +259,8 @@ class MacroSize(NamedTuple('MacroSize', [
         return MacroSize(
             library=str(d['library']),
             name=str(d['name']),
-            width=float(d['width']),
-            height=float(d['height'])
+            width=Decimal(str(d['width'])),
+            height=Decimal(str(d['height']))
         )
 
 

--- a/src/hammer-vlsi/cli_driver_test.py
+++ b/src/hammer-vlsi/cli_driver_test.py
@@ -9,6 +9,7 @@ import json
 import os
 import shutil
 import tempfile
+from decimal import Decimal
 from typing import Any, Callable, Dict, Optional
 
 import hammer_config
@@ -343,10 +344,11 @@ class CLIDriverTest(unittest.TestCase):
             dummy_placement = PlacementConstraint(
                 path="dummy",
                 type=PlacementConstraintType.Dummy,
-                x=0.0,
-                y=0.0,
-                width=10.0,
-                height=10.0,
+                x=Decimal("0"),
+                y=Decimal("0"),
+                width=Decimal("10"),
+                height=Decimal("10"),
+                master=None,
                 orientation=None,
                 margins=None,
                 top_layer=None,
@@ -449,8 +451,8 @@ class CLIDriverTest(unittest.TestCase):
         my_size = MacroSize(
             library='my_lib',
             name='my_cell',
-            width=100.0,
-            height=100.0
+            width=Decimal("100"),
+            height=Decimal("100")
         )
 
         def add_macro_sizes(d: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -231,31 +231,45 @@ vlsi.inputs:
   # List of placement constraints for floorplanning.
   # Each item is a struct member:
   # path (str) - Path to the given instance
-  # type (str) - One of the following:
-  # - "dummy" (does nothing with this constraint)
-  # - "placement" (creates a placement constraint for an instance)
-  # - "toplevel" (top-level chip dimensions; may only occur once, for the top-level module)
-  # - "hardmacro" (places this hard macro at a particular spot)
-  # - "hierarchical" (marks this instance as part of hierarchical place and route)
-  # - "obstruction" (creates a blockage at a particular spot; see obs_types)
-  # TODO(edwardw): add rotation
+  # - Required for all types
+  # type (str) - The type of placement constraint
+  # - Required for all types
+  # - One of the following:
+  #   - "dummy" (does nothing with this constraint)
+  #   - "placement" (creates a placement constraint for an instance)
+  #   - "toplevel" (top-level chip dimensions; may only occur once, for the top-level module)
+  #   - "hardmacro" (places this hard macro at a particular spot)
+  #   - "hierarchical" (marks this instance as part of hierarchical place and route)
+  #   - "obstruction" (creates a blockage at a particular spot; see obs_types)
+  # orientation (Optional[str]) - The orientation (MX, MY, R0, R90, R180, R270)
+  # - Optional for all types
   # x (float) - x coordinate in um
+  # - Required for all types
   # y (float) - y coordinate in um
+  # - Required for all types
   # width (float) - width in um
+  # - Required for all types, but can be auto-filled for hierarchical and hardmacro if left blank
   # height (float) - height in um
-  # margins (Optional[Margins]) - margins for the top-level module (i.e. only only for a toplevel constraint). Contains the following keys:
-  # - "left" - margin from the left side of the core PNR area to the edge of the chip
-  # - "right" - margin from the right side of the core PNR area to the edge of the chip
-  # - "top" - margin from the top side of the core PNR area to the edge of the chip
-  # - "bottom" - margin from the bottom side of the core PNR area to the edge of the chip
-  # top_layer (str) - Optional: Specifies the highest layer used by this hardmacro
-  #   If specified will be used to keep other wires away from this hardmacro
-  # layers (List[str]) - Optional: only used for obstruction type. 
-  #   If specified, a list of strings that enumerates layer(s) blocked by the obstruction otherwise all layers are blocked
-  # obs_types (List[str]) - Required for obstruction type. A list of one or more of the following:
-  # - "place" - This obstruction type stops the placement of standard cells inside it
-  # - "route" - This obstruction type stops all routing inside it
-  # - "power" - This obstruction type stops only power routing/straps inside it
+  # - Required for all types, but can be auto-filled for hierarchical and hardmacro if left blank
+  # master (Optional[str]) - The master module name of the hierarchical or hardmacro constraint
+  # - Required for hierarchical and optional for hardmacro, disallowed otherwise
+  # margins (Optional[Margins]) - margins for the top-level module.
+  # - Required for toplevel, disallowed otherwise
+  # - Contains the following keys:
+  #   - "left" - margin from the left side of the core PNR area to the edge of the chip
+  #   - "right" - margin from the right side of the core PNR area to the edge of the chip
+  #   - "top" - margin from the top side of the core PNR area to the edge of the chip
+  #   - "bottom" - margin from the bottom side of the core PNR area to the edge of the chip
+  # top_layer (str) - Specifies the highest layer used by this hierarchical or hardmacro, used to keep other wires away
+  # - Optional for hierarchical and hardmacro
+  # layers (List[str]) - A list of strings that enumerates layer(s) blocked by the obstruction otherwise all layers are blocked
+  # - Required for the obstruction type, disallowed otherwise
+  # obs_types (List[str]) - A list of the types of obstructions for the given geometry
+  # - Required for the obstruction type, disallowed otherwise
+  # - A list of one or more of the following:
+  #   - "place" - This obstruction type stops the placement of standard cells inside it
+  #   - "route" - This obstruction type stops all routing inside it
+  #   - "power" - This obstruction type stops only power routing/straps inside it
   placement_constraints: []
 
   # Don't use list mode. (str)

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -241,8 +241,17 @@ vlsi.inputs:
   #   - "hardmacro" (places this hard macro at a particular spot)
   #   - "hierarchical" (marks this instance as part of hierarchical place and route)
   #   - "obstruction" (creates a blockage at a particular spot; see obs_types)
-  # orientation (Optional[str]) - The orientation (MX, MY, R0, R90, R180, R270)
+  # orientation (Optional[str]) - The orientation
   # - Optional for all types
+  # - Valid options:
+  #   - "r0"   (standard orientation)
+  #   - "r90"  (rotated 90 degrees clockwise)
+  #   - "r180" (rotated 180 degrees)
+  #   - "r270" (rotated 270 degrees clockwise; equivalent to -90 degrees counterclockwise)
+  #   - "mx"   (mirrored about the x-axis)
+  #   - "mx90" (mirrored about the x-axis, then rotated 90 degrees clockwise)
+  #   - "my"   (mirrored about the y-axis)
+  #   - "my90" (mirrored about the y-axis, then rotated 90 degrees clockwise)
   # x (float) - x coordinate in um
   # - Required for all types
   # y (float) - y coordinate in um
@@ -256,10 +265,10 @@ vlsi.inputs:
   # margins (Optional[Margins]) - margins for the top-level module.
   # - Required for toplevel, disallowed otherwise
   # - Contains the following keys:
-  #   - "left" - margin from the left side of the core PNR area to the edge of the chip
-  #   - "right" - margin from the right side of the core PNR area to the edge of the chip
-  #   - "top" - margin from the top side of the core PNR area to the edge of the chip
-  #   - "bottom" - margin from the bottom side of the core PNR area to the edge of the chip
+  #   - "left"   (margin from the left side of the core PNR area to the edge of the chip)
+  #   - "right"  (margin from the right side of the core PNR area to the edge of the chip)
+  #   - "top"    (margin from the top side of the core PNR area to the edge of the chip)
+  #   - "bottom" (margin from the bottom side of the core PNR area to the edge of the chip)
   # top_layer (str) - Specifies the highest layer used by this hierarchical or hardmacro, used to keep other wires away
   # - Optional for hierarchical and hardmacro
   # layers (List[str]) - A list of strings that enumerates layer(s) blocked by the obstruction otherwise all layers are blocked

--- a/src/hammer-vlsi/hammer_utils/__init__.py
+++ b/src/hammer-vlsi/hammer_utils/__init__.py
@@ -364,7 +364,7 @@ def check_function_type(function: Callable, args: List[type], return_type: type)
             "Too many arguments - got {got}, expected {expected}".format(got=len(inspected_args), expected=len(args)))
     else:
         for i, (inspected_var_name, expected) in list(enumerate(zip(inspected_args, args))):
-            inspected = annotations[inspected_var_name]
+            inspected = annotations.get(inspected_var_name, None)
             if not compare_types(inspected, expected):
                 inspected_name = get_name_from_type(inspected)
                 expected_name = get_name_from_type(expected)

--- a/src/hammer-vlsi/hammer_utils/__init__.py
+++ b/src/hammer-vlsi/hammer_utils/__init__.py
@@ -109,20 +109,15 @@ def coerce_to_grid(num: float, grid: Decimal) -> Decimal:
     """
     return Decimal(round(num / float(grid))) * grid
 
-def check_on_grid(num: Union[float, Decimal], grid: Decimal) -> bool:
+def check_on_grid(num: Decimal, grid: Decimal) -> bool:
     """
     Checks if a number is an integer multiple of a specified grid unit.
-    This supports floats and Decimals, although support for floats will eventually be removed.
-    Removal of float support will be in ucb-bar/hammer#376
 
     :param num: The number to check
     :param grid: The decimal grid value on which to check number
     :return: True if num is on-grid, False otherwise
     """
-    # TODO(johnwright) Remove float support in ucb-bar/hammer#376
-    num_dec = num if isinstance(num, Decimal) else coerce_to_grid(num, Decimal("0.001"))
-    assert isinstance(num_dec, Decimal)
-    return Decimal(int(num_dec / grid)) == (num_dec / grid)
+    return Decimal(int(num / grid)) == (num / grid)
 
 def gcd(*values: int) -> int:
     """

--- a/src/hammer-vlsi/hammer_utils/lef_utils.py
+++ b/src/hammer-vlsi/hammer_utils/lef_utils.py
@@ -8,6 +8,7 @@
 #  See LICENSE for licence details.
 
 import re
+from decimal import Decimal
 from typing import List, Optional, Tuple
 
 __all__ = ['LEFUtils']
@@ -15,7 +16,7 @@ __all__ = ['LEFUtils']
 
 class LEFUtils:
     @staticmethod
-    def get_sizes(source: str) -> List[Tuple[str, float, float]]:
+    def get_sizes(source: str) -> List[Tuple[str, Decimal, Decimal]]:
         """
         Get the sizes of all macros in the given LEF source file.
 
@@ -24,7 +25,7 @@ class LEFUtils:
         """
         lines = source.split("\n")
 
-        output = []  # type: List[Tuple[str, float, float]]
+        output = []  # type: List[Tuple[str, Decimal, Decimal]]
 
         in_propertydefinitions = False  # type: bool
         in_macro = None  # type: Optional[str]
@@ -82,8 +83,8 @@ class LEFUtils:
             if regex_search:
                 if found_size:
                     raise ValueError("Found two SIZE statements in MACRO block for {m}".format(m=in_macro))
-                width = float(regex_search.group(1))
-                height = float(regex_search.group(2))
+                width = Decimal(regex_search.group(1))
+                height = Decimal(regex_search.group(2))
                 found_size = True
 
                 # Add size to output

--- a/src/hammer-vlsi/hammer_vlsi/constraints.py
+++ b/src/hammer-vlsi/hammer_vlsi/constraints.py
@@ -333,7 +333,7 @@ class PlacementConstraint(NamedTuple('PlacementConstraint', [
             matches = list(filter(lambda x: x.name == master, masters))
             if len(matches) > 0:
                 width_check = matches[0].width
-                height_check = matches[1].height
+                height_check = matches[0].height
             else:
                 raise ValueError("Could not find a master for hierarchical cell {} in masters list.".format(master))
         elif constraint_type == PlacementConstraintType.HardMacro:

--- a/src/hammer-vlsi/hammer_vlsi/constraints.py
+++ b/src/hammer-vlsi/hammer_vlsi/constraints.py
@@ -360,6 +360,7 @@ class PlacementConstraint(NamedTuple('PlacementConstraint', [
         else:
             if constraint_type not in checked_types:
                 raise ValueError("Constraints other than Hierarchical and HardMacro must contain width: {}".format(constraint))
+            assert isinstance(width_check, Decimal)
             width = width_check
 
         if "height" in constraint:
@@ -367,6 +368,7 @@ class PlacementConstraint(NamedTuple('PlacementConstraint', [
         else:
             if constraint_type not in checked_types:
                 raise ValueError("Constraints other than Hierarchical and HardMacro must contain height: {}".format(constraint))
+            assert isinstance(height_check, Decimal)
             height = height_check
 
         # Perform the check

--- a/src/hammer-vlsi/hammer_vlsi/driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/driver.py
@@ -835,7 +835,7 @@ class HammerDriver:
             # This filters out all of the Nones to get only hierarchical modules with toplevel placement constraints
             toplevels = {k: v for k, v in toplevels_opt.items() if v is not None}  # type: Dict[str, Dict[str, Any]]
             # This converts each dict entry into a MacroSize tuple, which should now represent all hierarchical modules
-            hier_macros = list(map(lambda x: MacroSize(library="", name=x[0], width=x[1]["width"], height=x[1]["height"]), toplevels.items()))
+            hier_macros = [MacroSize(library="", name=x[0], width=x[1]["width"], height=x[1]["height"]) for x in toplevels.items()]
             masters = hard_macros + hier_macros
 
             hier_placement_constraints = {key: list(map(partial(PlacementConstraint.from_masters_and_dict, masters), lst))

--- a/src/hammer-vlsi/hammer_vlsi/driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/driver.py
@@ -800,6 +800,7 @@ class HammerDriver:
         hier_placement_constraints = {}  # type: Dict[str, List[PlacementConstraint]]
         hier_constraints = {}  # type: Dict[str, List[Dict]]
 
+        # This is retrieving the list of hard macro sizes to be used when creating PlacementConstraint tuples later
         list_of_hard_macros = self.database.get_setting("vlsi.technology.extra_macro_sizes")  # type: List[Dict]
         hard_macros = list(map(MacroSize.from_setting, list_of_hard_macros))
 
@@ -818,6 +819,8 @@ class HammerDriver:
             assert isinstance(list_of_placement_constraints, list)
             combined_raw_placement_dict = reduce(add_dicts, list_of_placement_constraints, {})  # type: Dict[str, List[Dict[str, Any]]]
 
+            # This helper function filters only the dict containing the toplevel placement constraint, if any, from the provided list of dicts.
+            # If the list does not contain a toplevel constraint, it returns None.
             def get_toplevel(d: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
                 results = list(filter(lambda x: x["type"] == "toplevel", d))
                 if len(results) == 0:
@@ -825,12 +828,17 @@ class HammerDriver:
                 else:
                     return results[-1]
 
+            # Use the above helper method to filter down the combined raw placement dict into a dict:
+            # - keys are hierarchical module name
+            # - values are dicts containing toplevel constraints or None
             toplevels_opt = {k: get_toplevel(v) for k, v in combined_raw_placement_dict.items()}  # type: Dict[str, Optional[Dict[str, Any]]]
+            # This filters out all of the Nones to get only hierarchical modules with toplevel placement constraints
             toplevels = {k: v for k, v in toplevels_opt.items() if v is not None}  # type: Dict[str, Dict[str, Any]]
+            # This converts each dict entry into a MacroSize tuple, which should now represent all hierarchical modules
             hier_macros = list(map(lambda x: MacroSize(library="", name=x[0], width=x[1]["width"], height=x[1]["height"]), toplevels.items()))
             masters = hard_macros + hier_macros
 
-            hier_placement_constraints = {key: list(map(partial(PlacementConstraint.from_dict, masters), lst))
+            hier_placement_constraints = {key: list(map(partial(PlacementConstraint.from_masters_and_dict, masters), lst))
                                           for key, lst in combined_raw_placement_dict.items()}
             list_of_hier_constraints = self.database.get_setting(
                     "vlsi.inputs.hierarchical.constraints") # type: List[Dict]

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -11,7 +11,7 @@ import os
 import re
 import shlex
 from abc import ABCMeta, abstractmethod
-from functools import reduce, partial
+from functools import reduce
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, cast
 
 import hammer_config
@@ -1034,8 +1034,8 @@ class HammerTool(metaclass=ABCMeta):
         constraints = self.get_setting("vlsi.inputs.placement_constraints")
         assert isinstance(constraints, list)
         # At this point, the optional width/height placement constraints have been resolved,
-        # so there is no need to pass the masters in here.
-        return list(map(partial(PlacementConstraint.from_dict, []), constraints))
+        # so there is no need to pass the masters in here, meaning we can use from_dict.
+        return list(map(PlacementConstraint.from_dict, constraints))
 
     def get_mmmc_corners(self) -> List[MMMCCorner]:
         """

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -11,7 +11,7 @@ import os
 import re
 import shlex
 from abc import ABCMeta, abstractmethod
-from functools import reduce
+from functools import reduce, partial
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, cast
 
 import hammer_config
@@ -1033,7 +1033,9 @@ class HammerTool(metaclass=ABCMeta):
         """
         constraints = self.get_setting("vlsi.inputs.placement_constraints")
         assert isinstance(constraints, list)
-        return list(map(PlacementConstraint.from_dict, constraints))
+        # At this point, the optional width/height placement constraints have been resolved,
+        # so there is no need to pass the masters in here.
+        return list(map(partial(PlacementConstraint.from_dict, []), constraints))
 
     def get_mmmc_corners(self) -> List[MMMCCorner]:
         """

--- a/src/hammer-vlsi/lef_utils_test.py
+++ b/src/hammer-vlsi/lef_utils_test.py
@@ -6,6 +6,7 @@
 #  See LICENSE for licence details.
 
 from hammer_utils import LEFUtils
+from decimal import Decimal
 
 import unittest
 
@@ -42,7 +43,7 @@ MACRO my_awesome_macro
 END my_awesome_macro
 
 END LIBRARY"""
-        self.assertEqual(LEFUtils.get_sizes(lef_source), [("my_awesome_macro", 810.522, 607.525)])
+        self.assertEqual(LEFUtils.get_sizes(lef_source), [("my_awesome_macro", Decimal("810.522"), Decimal("607.525"))])
 
         lef_multiple_macros = """
 VERSION 5.6 ;
@@ -111,8 +112,8 @@ END MY_CELL_1
 END LIBRARY
         """
         self.assertEqual(LEFUtils.get_sizes(lef_multiple_macros), [
-            ("MY_CELL_0", 2.718, 3.141),
-            ("MY_CELL_1", 3.000, 3.000)
+            ("MY_CELL_0", Decimal("2.718"), Decimal("3.141")),
+            ("MY_CELL_1", Decimal("3.000"), Decimal("3.000"))
         ])
 
 

--- a/src/hammer-vlsi/tech_test.py
+++ b/src/hammer-vlsi/tech_test.py
@@ -525,7 +525,7 @@ END LIBRARY
         # Test that macro sizes can be read out of the LEF.
         self.assertEqual(tech.get_macro_sizes(), [
             hammer_tech.MacroSize(library='my_vendor_lib', name='my_awesome_macro',
-                                  width=810.522, height=607.525)
+                                  width=Decimal("810.522"), height=Decimal("607.525"))
         ])
 
         # Cleanup

--- a/src/hammer-vlsi/utils_test.py
+++ b/src/hammer-vlsi/utils_test.py
@@ -8,7 +8,7 @@
 from typing import Dict, Tuple, List, Optional, Union
 from decimal import Decimal
 
-from hammer_utils import (topological_sort, get_or_else, optional_map, assert_function_type,
+from hammer_utils import (topological_sort, get_or_else, optional_map, assert_function_type, check_function_type,
                           gcd, lcm, lcm_grid, coerce_to_grid, check_on_grid)
 
 import unittest
@@ -137,6 +137,14 @@ class UtilsTest(unittest.TestCase):
         assert_function_type(test8, ["int"], list)  # type: ignore
         assert_function_type(test8, [int], "list")  # type: ignore
         assert_function_type(test8, [int], list)
+
+        # Check that untyped arguments don't crash.
+        def test9(x) -> str:
+            return str(x)
+
+        test9_return = check_function_type(test9, [int], str)
+        assert test9_return is not None
+        self.assertTrue("incorrect signature" in test9_return)
 
         with self.assertRaises(TypeError):
             # Different # of arguments

--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -9,6 +9,7 @@
 
 # pylint: disable=invalid-name
 
+from decimal import Decimal
 from typing import Iterable, List, Union, Callable, Any, Dict, Set, NamedTuple, Tuple, Optional
 
 from hammer_utils import deepdict, topological_sort
@@ -19,6 +20,14 @@ import json
 import numbers
 import os
 import re
+
+# A heler class that writes Decimals as strings
+class HammerJSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, Decimal):
+            # from https://stackoverflow.com/questions/1960516/python-json-serialize-a-decimal-object
+            return float(o)
+        return super(HammerJSONEncoder, self).default(o)
 
 # Special key used for meta directives which require config paths like prependlocal.
 _CONFIG_PATH_KEY = "_config_path"
@@ -588,7 +597,8 @@ class HammerDatabase:
     def get_database_json(self) -> str:
         """Get the database (get_config) in JSON form as a string.
         """
-        return json.dumps(self.get_config(), sort_keys=True, indent=4, separators=(',', ': '))
+        # The cls=HammerJSONEncoder enables writing Decimals
+        return json.dumps(self.get_config(), cls=HammerJSONEncoder, sort_keys=True, indent=4, separators=(',', ': '))
 
     def get(self, key: str) -> Any:
         """Alias for get_setting()."""


### PR DESCRIPTION
Switch margins and constraints over to Decimal and make width/height for hard macros optional.