### PR TITLE
Fix JSON serialization bug with Decimals

### DIFF
--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -452,7 +452,7 @@ class HammerTechnology:
             raise TypeError("lib must be a dict")
 
         # Convert the dict to JSON...
-        return Library.from_json(json.dumps(lib), cls=HammerJSONEncoder)
+        return Library.from_json(json.dumps(lib, cls=HammerJSONEncoder))
 
     @property
     def tech_defined_libraries(self) -> List[Library]:

--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -16,7 +16,7 @@ from decimal import Decimal
 import hammer_config
 import python_jsonschema_objects  # type: ignore
 
-from hammer_config import load_yaml
+from hammer_config import load_yaml, HammerJSONEncoder
 from hammer_logging import HammerVLSILoggingContext
 from hammer_utils import (LEFUtils, add_lists, deeplist, get_or_else,
                           in_place_unique, optional_map, reduce_list_str,
@@ -363,7 +363,7 @@ class HammerTechnology:
         :param yaml_str: yaml string to use as the technology yaml
         :param path: Path to set as the technology folder (e.g. foo/bar/technology/saed32)
         """
-        return HammerTechnology.load_from_json(technology_name, json.dumps(load_yaml(yaml_str)), path)
+        return HammerTechnology.load_from_json(technology_name, json.dumps(load_yaml(yaml_str), cls=HammerJSONEncoder), path)
 
     def set_database(self, database: hammer_config.HammerDatabase) -> None:
         """Set the settings database for use by the tool."""
@@ -452,7 +452,7 @@ class HammerTechnology:
             raise TypeError("lib must be a dict")
 
         # Convert the dict to JSON...
-        return Library.from_json(json.dumps(lib))
+        return Library.from_json(json.dumps(lib), cls=HammerJSONEncoder)
 
     @property
     def tech_defined_libraries(self) -> List[Library]:
@@ -494,7 +494,7 @@ class HammerTechnology:
                 name = ""
             else:
                 name = str(lib_name)
-            return [json.dumps([paths[0], name])]
+            return [json.dumps([paths[0], name], cls=HammerJSONEncoder)]
 
         lef_filter_plus = filters.lef_filter._replace(extraction_func=extraction_func)
 

--- a/src/hammer-vlsi/cli_driver_test.py
+++ b/src/hammer-vlsi/cli_driver_test.py
@@ -45,7 +45,7 @@ class CLIDriverTest(unittest.TestCase):
             config = postprocessing_func(config)
 
         with open(config_path, "w") as f:
-            f.write(json.dumps(config, indent=4))
+            f.write(json.dumps(config, cls=HammerJSONEncoder, indent=4))
 
         return config
 
@@ -305,7 +305,7 @@ class CLIDriverTest(unittest.TestCase):
         with open(config_packed_path, "r") as f:
             unpacked_config = hammer_config.reverse_unpack(json.loads(f.read()))
         with open(config_path, "w") as f:
-            f.write(json.dumps(unpacked_config, indent=4))
+            f.write(json.dumps(unpacked_config, cls=HammerJSONEncoder, indent=4))
 
         # Check that running the CLIDriver executes successfully (code 0).
         with self.assertRaises(SystemExit) as cm:  # type: ignore

--- a/src/hammer-vlsi/cli_driver_test.py
+++ b/src/hammer-vlsi/cli_driver_test.py
@@ -13,6 +13,7 @@ from decimal import Decimal
 from typing import Any, Callable, Dict, Optional
 
 import hammer_config
+from hammer_config import HammerJSONEncoder
 from hammer_logging.test import HammerLoggingCaptureContext
 from hammer_tech import MacroSize
 from hammer_vlsi import CLIDriver, HammerDriver, PlacementConstraint, PlacementConstraintType

--- a/src/hammer-vlsi/hammer_vlsi/cli_driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/cli_driver.py
@@ -20,6 +20,8 @@ from typing import List, Dict, Tuple, Any, Callable, Optional, Union, cast
 
 from hammer_utils import add_dicts, deeplist, deepdict, get_or_else, check_function_type
 
+from hammer_config import HammerJSONEncoder
+
 
 def parse_optional_file_list_from_args(args_list: Any, append_error_func: Callable[[str], None]) -> List[str]:
     """Parse a possibly null list of files, validate the existence of each file, and return a list of paths (possibly
@@ -53,7 +55,7 @@ def dump_config_to_json_file(output_path: str, config: dict) -> None:
     :param config: Config dictionary to dump
     """
     with open(output_path, "w") as f:
-        f.write(json.dumps(config, indent=4))
+        f.write(json.dumps(config, cls=HammerJSONEncoder, indent=4))
 
 
 # Type signature of a CLIDriver action that returns a config dictionary.
@@ -191,7 +193,7 @@ class CLIDriver:
         Dump macro size information.
         """
         macro_json = list(map(lambda m: m.to_setting(), driver.tech.get_macro_sizes()))
-        return json.dumps(macro_json, indent=4)
+        return json.dumps(macro_json, cls=HammerJSONEncoder, indent=4)
 
     def get_extra_synthesis_hooks(self) -> List[HammerToolHookAction]:
         """
@@ -748,7 +750,7 @@ class CLIDriver:
                         new_output_json = json.dumps(d.project_config, indent=4)
                         f.write(new_output_json)
                     with open(os.path.join(rundir, "module_config.json"), "w") as f:
-                        new_output_json = json.dumps(config, indent=4)
+                        new_output_json = json.dumps(config, cls=HammerJSONEncoder, indent=4)
                         f.write(new_output_json)
 
                     d.update_project_configs(deeplist(base_project_config[0]))

--- a/src/hammer-vlsi/hammer_vlsi/cli_driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/cli_driver.py
@@ -747,7 +747,7 @@ class CLIDriver:
                 def post_run(d: HammerDriver, rundir: str) -> None:
                     # Write out the configs used/generated for logging/debugging.
                     with open(os.path.join(rundir, "full_config.json"), "w") as f:
-                        new_output_json = json.dumps(d.project_config, indent=4)
+                        new_output_json = json.dumps(d.project_config, cls=HammerJSONEncoder, indent=4)
                         f.write(new_output_json)
                     with open(os.path.join(rundir, "module_config.json"), "w") as f:
                         new_output_json = json.dumps(config, cls=HammerJSONEncoder, indent=4)
@@ -808,7 +808,7 @@ class CLIDriver:
                     b, ext = os.path.splitext(args["output"])
                     new_output_filename = "{base}-{module}{ext}".format(base=b, module=module, ext=ext)
                     with open(new_output_filename, "w") as f:
-                        new_output_json = json.dumps(new_output, indent=4)
+                        new_output_json = json.dumps(new_output, cls=HammerJSONEncoder, indent=4)
                         f.write(new_output_json)
                     log.info("Output JSON: " + str(new_output))
 
@@ -818,7 +818,7 @@ class CLIDriver:
                     }
                     new_ilm_filename = "{base}-{module}_ilm{ext}".format(base=b, module=module, ext=ext)
                     with open(new_ilm_filename, "w") as f:
-                        json_content = json.dumps(new_ilm, indent=4)
+                        json_content = json.dumps(new_ilm, cls=HammerJSONEncoder, indent=4)
                         f.write(json_content)
                     log.info("New input ILM JSON written to " + new_ilm_filename)
                     driver.update_project_configs(driver.project_configs + [new_ilm])
@@ -853,7 +853,7 @@ class CLIDriver:
             action_func = cast(CLIActionConfigType, action_func)
             output_config = action_func(driver, errors.append)  # type: Optional[dict]
             if output_config is not None:
-                output_str = json.dumps(output_config, indent=4)
+                output_str = json.dumps(output_config, cls=HammerJSONEncoder, indent=4)
         elif is_string_action(action_func):
             action_func = cast(CLIActionStringType, action_func)
             output_str = action_func(driver, errors.append)

--- a/src/hammer-vlsi/par/mockpar/__init__.py
+++ b/src/hammer-vlsi/par/mockpar/__init__.py
@@ -8,6 +8,7 @@
 #  See LICENSE for licence details.
 
 from hammer_vlsi import HammerPlaceAndRouteTool, DummyHammerTool, HammerToolStep, deepdict
+from hammer_config import HammerJSONEncoder
 
 from typing import Dict, List, Any, Optional
 from decimal import Decimal
@@ -64,7 +65,7 @@ class MockPlaceAndRoute(HammerPlaceAndRouteTool, DummyHammerTool):
             "nets": list(map(str, nets)),
             "add_pins": add_pins
         }
-        return [json.dumps(output_dict)]
+        return [json.dumps(output_dict, cls=HammerJSONEncoder)]
 
     def specify_std_cell_power_straps(self, blockage_spacing: Decimal, bbox: Optional[List[Decimal]], nets: List[str]) -> List[str]:
         layer_name = self.get_setting("technology.core.std_cell_rail_layer")
@@ -75,7 +76,7 @@ class MockPlaceAndRoute(HammerPlaceAndRouteTool, DummyHammerTool):
             "bbox": [] if bbox is None else list(map(str, bbox)),
             "nets": list(map(str, nets))
         }
-        return [json.dumps(output_dict)]
+        return [json.dumps(output_dict, cls=HammerJSONEncoder)]
 
     def fill_outputs(self) -> bool:
         self.output_gds = "/dev/null"

--- a/src/hammer-vlsi/tech_test.py
+++ b/src/hammer-vlsi/tech_test.py
@@ -20,6 +20,7 @@ from hammer_logging import HammerVLSILogging
 import hammer_tech
 from hammer_tech import LibraryFilter, Stackup, Metal, WidthSpacingTuple
 from hammer_utils import deepdict
+from hammer_config import HammerJSONEncoder
 from decimal import Decimal
 
 from test_tool_utils import HammerToolTestHelpers, DummyTool
@@ -73,7 +74,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
                 name = ""
             else:
                 name = str(lib.name)
-            return [json.dumps({"path": paths[0], "name": name}, indent=4)]
+            return [json.dumps({"path": paths[0], "name": name}, cls=HammerJSONEncoder, indent=4)]
 
         def sort_func(lib: hammer_tech.Library):
             assert lib.milkyway_techfile is not None
@@ -175,7 +176,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
         with open(os.path.join(tech_dir, "defaults.json"), "w") as f:
             f.write(json.dumps({
                 "technology.dummy28.tarball_dir": tech_dir
-            }))
+            }, cls=HammerJSONEncoder))
 
         HammerToolTestHelpers.write_tech_json(tech_json_filename, self.add_tarballs)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
@@ -208,7 +209,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
             f.write(json.dumps({
                 "technology.dummy28.tarball_dir": tech_dir,
                 "vlsi.technology.extracted_tarballs_dir": tech_dir_base
-            }))
+            }, cls=HammerJSONEncoder))
 
         HammerToolTestHelpers.write_tech_json(tech_json_filename, self.add_tarballs)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
@@ -243,7 +244,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
                 "technology.dummy28.tarball_dir": tech_dir,
                 "vlsi.technology.extracted_tarballs_dir": "/should/not/be/used",
                 "technology.dummy28.extracted_tarballs_dir": tech_dir_base
-            }))
+            }, cls=HammerJSONEncoder))
 
         HammerToolTestHelpers.write_tech_json(tech_json_filename, self.add_tarballs)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
@@ -297,7 +298,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
         }
 
         tech_dir = "/tmp/path"  # should not be used
-        tech = hammer_tech.HammerTechnology.load_from_json("dummy28", json.dumps(tech_json, indent=2), tech_dir)
+        tech = hammer_tech.HammerTechnology.load_from_json("dummy28", json.dumps(tech_json, cls=HammerJSONEncoder, indent=2), tech_dir)
 
         # Check that a tech-provided prefix works fine
         self.assertEqual("{0}/water".format(tech_dir), tech.prepend_dir_path("test/water"))

--- a/src/hammer-vlsi/test.py
+++ b/src/hammer-vlsi/test.py
@@ -18,6 +18,7 @@ from tech_test_utils import HasGetTech
 from test_tool_utils import HammerToolTestHelpers, DummyTool, SingleStepTool
 
 import hammer_config
+from hammer_config import HammerJSONEncoder
 import hammer_tech
 import hammer_vlsi
 from hammer_logging import HammerVLSIFileLogger, HammerVLSILogging, Level
@@ -212,7 +213,7 @@ class HammerToolTest(HasGetTech, unittest.TestCase):
             ]
         }
         with open(tech_json_filename, "w") as f:
-            f.write(json.dumps(tech_json, indent=4))
+            f.write(json.dumps(tech_json, cls=HammerJSONEncoder, indent=4))
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
         tech.logger = HammerVLSILogging.context("")
@@ -425,7 +426,7 @@ export lol=abc"cat"
                 "vlsi.core.par_tool": "nop",
                 "synthesis.inputs.top_module": "dummy",
                 "synthesis.inputs.input_files": ("/dev/null",)
-            }, indent=4))
+            }, cls=HammerJSONEncoder, indent=4))
 
         class BadExportTool(hammer_vlsi.HammerSynthesisTool, DummyTool):
             def export_config_outputs(self) -> Dict[str, Any]:
@@ -803,7 +804,7 @@ export lol=abc"cat"
                 ]
             }
         with open(proj_config, "w") as f:
-            f.write(json.dumps(settings, indent=4))
+            f.write(json.dumps(settings, cls=HammerJSONEncoder, indent=4))
 
         driver = hammer_vlsi.HammerDriver(
             hammer_vlsi.HammerDriver.get_default_driver_options()._replace(project_configs=[
@@ -838,7 +839,7 @@ export lol=abc"cat"
                 ]
 
         with open(proj_config, "w") as f:
-            f.write(json.dumps(settings, indent=4))
+            f.write(json.dumps(settings, cls=HammerJSONEncoder, indent=4))
 
         driver = hammer_vlsi.HammerDriver(
             hammer_vlsi.HammerDriver.get_default_driver_options()._replace(project_configs=[
@@ -882,7 +883,7 @@ class HammerToolHooksTestContext:
                 "synthesis.inputs.top_module": "dummy",
                 "synthesis.inputs.input_files": ("/dev/null",),
                 "synthesis.mocksynth.temp_folder": temp_dir
-            }, indent=4))
+            }, cls=HammerJSONEncoder, indent=4))
         options = hammer_vlsi.HammerDriverOptions(
             environment_configs=[],
             project_configs=[json_path],
@@ -1179,7 +1180,7 @@ class HammerSubmitCommandTestContext:
             })
 
         with open(json_path, "w") as f:
-            f.write(json.dumps(json_content, indent=4))
+            f.write(json.dumps(json_content, cls=HammerJSONEncoder, indent=4))
 
         options = hammer_vlsi.HammerDriverOptions(
             environment_configs=[],
@@ -1281,7 +1282,7 @@ class HammerSignoffToolTestContext:
             })
 
         with open(json_path, "w") as f:
-            f.write(json.dumps(json_content, indent=4))
+            f.write(json.dumps(json_content, cls=HammerJSONEncoder, indent=4))
 
         options = hammer_vlsi.HammerDriverOptions(
             environment_configs=[],
@@ -1376,7 +1377,7 @@ class HammerSRAMGeneratorToolTestContext:
             })
 
         with open(json_path, "w") as f:
-            f.write(json.dumps(json_content, indent=4))
+            f.write(json.dumps(json_content, cls=HammerJSONEncoder, indent=4))
 
         options = hammer_vlsi.HammerDriverOptions(
             environment_configs=[],
@@ -1465,7 +1466,7 @@ class HammerPowerStrapsTestContext:
                 "technology.core.std_cell_rail_layer": "M1",
                 "technology.core.tap_cell_rail_reference": "FakeTapCell",
                 "par.mockpar.temp_folder": temp_dir
-            }, self.strap_options), indent=4))
+            }, cls=HammerJSONEncoder, self.strap_options), indent=4))
         options = hammer_vlsi.HammerDriverOptions(
             environment_configs=[],
             project_configs=[json_path],

--- a/src/hammer-vlsi/test.py
+++ b/src/hammer-vlsi/test.py
@@ -1466,7 +1466,7 @@ class HammerPowerStrapsTestContext:
                 "technology.core.std_cell_rail_layer": "M1",
                 "technology.core.tap_cell_rail_reference": "FakeTapCell",
                 "par.mockpar.temp_folder": temp_dir
-            }, cls=HammerJSONEncoder, self.strap_options), indent=4))
+            }, self.strap_options), cls=HammerJSONEncoder, indent=4))
         options = hammer_vlsi.HammerDriverOptions(
             environment_configs=[],
             project_configs=[json_path],

--- a/src/hammer-vlsi/test_tool_utils.py
+++ b/src/hammer-vlsi/test_tool_utils.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import hammer_tech
 from hammer_tech import LibraryFilter
+from hammer_config import HammerJSONEncoder
 import hammer_vlsi
 
 
@@ -109,7 +110,7 @@ class HammerToolTestHelpers:
         if postprocessing_func is not None:
             tech_json = postprocessing_func(tech_json)
         with open(tech_json_filename, "w") as f:  # pylint: disable=invalid-name
-            f.write(json.dumps(tech_json, indent=4))
+            f.write(json.dumps(tech_json, cls=HammerJSONEncoder, indent=4))
 
     @staticmethod
     def make_test_filter() -> LibraryFilter:

--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -21,7 +21,8 @@ import numbers
 import os
 import re
 
-# A heler class that writes Decimals as strings
+# A helper class that writes Decimals as strings
+# TODO(ucb-bar/hammer#378) get rid of this and serialize units
 class HammerJSONEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, Decimal):

--- a/src/hammer_config/yaml2json.py
+++ b/src/hammer_config/yaml2json.py
@@ -102,6 +102,7 @@ def load_yaml(yamlStr: str) -> dict:
     :return: A dictionary object representing the yaml database.
     """
     obj = convertArrays(yaml.safe_load(yamlStr))
+    # Note we are not using HammerJSONEncoder here to avoid a circular dependency, but this should never need have Decimals
     obj2 = json.loads(json.dumps(obj))
     if not compare(obj, obj2):
         raise ValueError("YAML -> JSON structures don't match: %s and %s do not match" % (str(obj), str(obj2)))


### PR DESCRIPTION
One of the CLI driver `json.dumps` needed the special Hammer serializer to work with Decimals. I think we should get rid of this when we solve #378 by not serializing `Decimal`s directly.