### PR TITLE
Add absolute track_offset

### DIFF
--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -542,6 +542,7 @@ par:
 
   # Spacing around blocks and hardmacros in microns
   # Used by power straps and floorplanning
+  # type: Decimal
   blockage_spacing: 0.0
 
   # If power_straps_mode is 'generate', which method to use.
@@ -555,34 +556,42 @@ par:
     by_tracks:
       # Spacing from end of strap to a block or blockage
       # Overrideable by appending _<layer name>
+      # type: Decimal
       blockage_spacing: "par.blockage_spacing"
       blockage_spacing_meta: lazycrossref
 
       # Number of routing tracks to be consumed by an individual strap
       # Overrideable by appending _<layer name>
+      # type: int
       track_width: 5
 
       # The first track to contain a power stripe
       # Overrideable by appending _<layer name>
+      # type: int
       # TODO(johnwright): include an auto-center option
       track_start: 0
 
       # Absolute offset for straps relative to the design bounding box origin
       # Overrideable by appending _<layer name>
-      track_offset: 0
+      # type: Decimal
+      track_offset: 0.0
 
       # Number of routing tracks between sets of straps (0 is recommended)
       # Overrideable by appending _<layer name>
+      # type: int
       track_spacing: 0
 
       # Ratio of total routing tracks to dedicate to power straps, which is used to calculate set pitch
       # Overrideable by appending _<layer name>
+      # type: float
       power_utilization: 0.1
 
       # Layers to put power pins on
+      # type: List[str]
       pin_layers: []
 
       # List of layers on which to place power straps (std cell rail layer is implied - do not include it)
+      # type: List[str]
       strap_layers: []
 
 mentor:

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -567,6 +567,10 @@ par:
       # TODO(johnwright): include an auto-center option
       track_start: 0
 
+      # Absolute offset for straps relative to the design bounding box origin
+      # Overrideable by appending _<layer name>
+      track_offset: 0
+
       # Number of routing tracks between sets of straps (0 is recommended)
       # Overrideable by appending _<layer name>
       track_spacing: 0

--- a/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py
@@ -576,6 +576,7 @@ class HammerPlaceAndRouteTool(HammerTool):
             track_spacing = int(self._get_by_tracks_metal_setting("track_spacing", layer_name))
             track_start = int(self._get_by_tracks_metal_setting("track_start", layer_name))
             track_pitch = self._get_by_tracks_track_pitch(layer_name)
+            track_offset = Decimal(str(self._get_by_tracks_metal_setting("track_offset", layer_name)))
             offset = layer.offset # TODO this is relaxable if we can auto-recalculate this based on hierarchical setting
 
             add_pins = layer_name in pin_layers
@@ -589,7 +590,7 @@ class HammerPlaceAndRouteTool(HammerTool):
             layer_is_all_power = (2 * track_width) == track_pitch
             for i in range(sum_weights):
                 nets = [ground_net, power_nets[i]]
-                group_offset = offset + track_pitch * i * layer.pitch
+                group_offset = offset + track_offset + track_pitch * i * layer.pitch
                 group_pitch = sum_weights * track_pitch
                 output.extend(self.specify_power_straps_by_tracks(layer_name, last.name, blockage_spacing, group_pitch, track_width, track_spacing, track_start, group_offset, bbox, nets, add_pins, layer_is_all_power))
             last = layer

--- a/src/hammer-vlsi/test.py
+++ b/src/hammer-vlsi/test.py
@@ -1606,7 +1606,8 @@ class HammerPowerStrapsTest(HasGetTech, unittest.TestCase):
         track_spacing_M6 = 1
         power_utilization = 0.2
         power_utilization_M8 = 1.0
-        track_offset_M5 = 1
+        track_start_M5 = 1
+        track_offset_M5 = 1.2
 
         # VSS comes before VDD
         nets = ["VSS", "VDD"]
@@ -1630,6 +1631,7 @@ class HammerPowerStrapsTest(HasGetTech, unittest.TestCase):
                 "track_spacing_M6": track_spacing_M6,
                 "power_utilization": power_utilization,
                 "power_utilization_M8": power_utilization_M8,
+                "track_start_M5": track_start_M5,
                 "track_offset_M5": track_offset_M5
             }
         }
@@ -1664,7 +1666,9 @@ class HammerPowerStrapsTest(HasGetTech, unittest.TestCase):
                 metal = stackup.get_metal(layer_name)
                 min_width = metal.min_width
                 group_track_pitch = strap_pitch / metal.pitch
-                used_tracks = round(Decimal(strap_offset + strap_width + strap_spacing + strap_width + strap_offset) / metal.pitch) - 1
+                track_offset = Decimal(str(track_offset_M5)) if layer_name == "M5" else Decimal(0)
+                track_start = Decimal(str(track_start_M5)) if layer_name == "M5" else Decimal(0)
+                used_tracks = round(Decimal(strap_offset + strap_width + strap_spacing + strap_width + strap_offset - 2 * (track_offset + track_start * metal.pitch)) / metal.pitch) - 1
                 if layer_name == "M4":
                     self.assertEqual(entry["bbox"], [])
                     self.assertEqual(entry["nets"], nets)
@@ -1674,6 +1678,9 @@ class HammerPowerStrapsTest(HasGetTech, unittest.TestCase):
                     self.assertEqual(entry["nets"], nets)
                     # Check that the requested tracks equals the used tracks
                     requested_tracks = track_width * 2 + track_spacing
+                    print(metal.pitch)
+                    print(track_width)
+                    print(track_spacing)
                     self.assertEqual(used_tracks, requested_tracks)
                     # Spacing should be at least the min spacing
                     min_spacing = metal.get_spacing_for_width(strap_width)

--- a/src/hammer-vlsi/test.py
+++ b/src/hammer-vlsi/test.py
@@ -1678,9 +1678,6 @@ class HammerPowerStrapsTest(HasGetTech, unittest.TestCase):
                     self.assertEqual(entry["nets"], nets)
                     # Check that the requested tracks equals the used tracks
                     requested_tracks = track_width * 2 + track_spacing
-                    print(metal.pitch)
-                    print(track_width)
-                    print(track_spacing)
                     self.assertEqual(used_tracks, requested_tracks)
                     # Spacing should be at least the min spacing
                     min_spacing = metal.get_spacing_for_width(strap_width)


### PR DESCRIPTION
This is needed to add an absolute offset to the power strap start position relative to the design's bounding box.

This is very useful to align power straps between blocks in hierarchical P&R.