### PR TITLE
replace python-gdsii with gdspy

### DIFF
--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -394,8 +394,12 @@ class HammerTechnology:
         # try to override tech, if __init__.py exist.
         try:
             mod = importlib.import_module(technology_name)
-            tech = mod.tech
-        except ModuleNotFoundError:
+            # work around for python < 3.6
+            try: 
+                tech = mod.tech
+            except:
+                raise ImportError
+        except ImportError:
             tech = HammerTechnology()
 
         # Name of the technology

--- a/src/hammer-vlsi/technology/asap7/__init__.py
+++ b/src/hammer-vlsi/technology/asap7/__init__.py
@@ -9,11 +9,8 @@ import re
 import os
 import tempfile
 import shutil
-from copy import deepcopy
 
-from gdsii.library import Library
-from gdsii.elements import *
-
+import gdspy
 from hammer_tech import HammerTechnology
 
 class ASAP7Tech(HammerTechnology):
@@ -52,32 +49,52 @@ class ASAP7Tech(HammerTechnology):
         vendor only provide SLVT gds, this patch will generate other 3(LVT, RVT, SRAM) VT gds file.
         """
         self.logger.info("generate gds for Multi-VT cells")
-        # Read original GDS (argument is filename)
+
         orig_gds = os.path.join(self.extracted_tarballs_dir, "ASAP7_PDKandLIB.tar/ASAP7_PDKandLIB_v1p5/asap7libs_24.tar.bz2/asap7libs_24/gds/asap7sc7p5t_24.gds")
-        with open(orig_gds, 'rb') as stream:
-            lib = Library.load(stream)
+        # load original_gds
+        asap7_original_gds = gdspy.GdsLibrary(infile=orig_gds)
+        original_cells = asap7_original_gds.cell_dict
+        # WTF is this?
+        del original_cells['m1_template']
+        # required libs
+        multi_libs = {
+            "R": {
+                "lib": gdspy.GdsLibrary(),
+                "mvt_layer": None,
+                },
+            "L": {
+                "lib": gdspy.GdsLibrary(),
+                "mvt_layer": 98
+                },
+            "SL": {
+                "lib": gdspy.GdsLibrary(),
+                "mvt_layer": 97
+                },
+            "SRAM": {
+                "lib": gdspy.GdsLibrary(),
+                "mvt_layer": 110
+                },
+        }
+        # create new libs
+        for vt, multi_lib in multi_libs.items():
+            multi_lib["lib"].name = asap7_original_gds.name.replace('SL', vt)
 
-        # Define threshold to layer mapping
-        layermap = {'R': None, 'L': 98, 'SL': 97, 'SRAM': 110}
+        for cell in original_cells.values():
+            poly_dict = cell.get_polygons(by_spec=True)
+            # extract polygon from layer 100(the boundary for cell)
+            boundary_polygon = poly_dict[(100, 0)]
+            for vt, multi_lib in multi_libs.items():
+                mvt_layer = multi_lib['mvt_layer']
+                if mvt_layer:
+                    # copy boundary_polygon to mvt_layer to mark the this cell is a mvt cell.
+                    mvt_polygon = gdspy.PolygonSet(boundary_polygon, multi_lib['mvt_layer'], 0)
+                    mvt_cell = cell.copy(name=cell.name.replace('SL', vt), exclude_from_current=True, deep_copy=True).add(mvt_polygon)
+                    # add mvt_cell to corresponding multi_lib
+                    multi_lib['lib'].add(mvt_cell)
 
-        for vt, num in layermap.items():
-            # Make a new copy of the library
-            new_lib = deepcopy(lib)
-
-            # Iterate through all cells, change cell name, copy boundary as new Vt layer, and write the GDS
-            for cell in new_lib:
-                cell.name = cell.name.decode('utf-8').replace('SL', vt).encode('utf-8')
-                if num is not None:
-                    for el in cell:
-                        if el.layer == 100: #BOUNDARY
-                            new_el = deepcopy(el)
-                            new_el.layer = num
-                            cell.append(new_el)
-
-            # Write to new GDS
-            new_gds = os.path.splitext(orig_gds)[0] + '_' + vt + '.gds'
-            with open(new_gds, 'wb') as stream:
-                new_lib.save(stream)
+        for vt, multi_lib in multi_libs.items():
+            # write multi_lib
+            multi_lib['lib'].write_gds(os.path.splitext(orig_gds)[0] + '_' + vt + '.gds')
 
     def fix_sram_cdl_bug(self) -> None:
         """


### PR DESCRIPTION
This PR requires #512.

Since https://github.com/ucb-bar/hammer/pull/511#issuecomment-530627815
This PR replace `python-gdsii` with `gdspy` for the manipulation to gds in `post_par_script` hook to solve the precision problem in the asap7.