### PR TITLE
power_spec_type is not optional, null is invalid

### DIFF
--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -345,7 +345,7 @@ vlsi.inputs:
   # Valid options:
   # cpf - Use the common power format commonly used in Cadence tools
   # upf - Use the universal power format, IEEE 1801-2015
-  power_spec_type: null
+  power_spec_type: upf
   # Optional: Contents of a power specification in the above type (str)
   power_spec_contents: null
 


### PR DESCRIPTION
https://github.com/ucb-bar/hammer/blob/master/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py#L1655 
type is not optional. 