### PR TITLE
Power strap API checks density & against width table

### DIFF
--- a/src/hammer-tech/schema.json
+++ b/src/hammer-tech/schema.json
@@ -307,13 +307,7 @@
                   "type": "array",
                   "items": {
                     "title": "WidthTableEntry",
-                    "type": "object",
-                    "additionalproperties": false,
-                    "properties": {
-                      "width": {
-                        "type": "number"
-                      }
-                    }
+                    "type": "number"
                   }
                 }
               }

--- a/src/hammer-tech/schema.json
+++ b/src/hammer-tech/schema.json
@@ -302,6 +302,19 @@
                       }
                     }
                   }
+                },
+                "power_strap_width_table": {
+                  "type": "array",
+                  "items": {
+                    "title": "WidthTableEntry",
+                    "type": "object",
+                    "additionalproperties": false,
+                    "properties": {
+                      "width": {
+                        "type": "number"
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/src/hammer-tech/stackup.py
+++ b/src/hammer-tech/stackup.py
@@ -7,7 +7,7 @@
 #  See LICENSE for licence details.
 
 from enum import Enum
-from typing import List, NamedTuple, Tuple, Dict
+from typing import List, NamedTuple, Tuple, Dict, Optional
 from hammer_utils import reverse_dict, coerce_to_grid
 from hammer_logging import HammerVLSILoggingContext
 from decimal import Decimal
@@ -239,7 +239,7 @@ class Metal(NamedTuple('Metal', [
         """
         return self.min_spacing_and_max_width_from_pitch(pitch)[1]
 
-    def quantize_to_width_table(self, width: Decimal, layer: str, logger: HammerVLSILoggingContext) -> Decimal:
+    def quantize_to_width_table(self, width: Decimal, layer: str, logger: Optional[HammerVLSILoggingContext]) -> Decimal:
         """
         Compare a desired width to the width table, if specified for a technology.
         Will return the allowable width smaller than or equal to the desired width,
@@ -262,12 +262,13 @@ class Metal(NamedTuple('Metal', [
                     qwidth = w
                     break
                 else:
-                    logger.warning("The desired power strap width {dw} on {lay} was quantized down to {fw} based on the technology's width table. Please check your power grid.".format(dw=str(width), lay=layer, fw=str(width_table[i-1])))
+                    if logger is not None:
+                        logger.warning("The desired power strap width {dw} on {lay} was quantized down to {fw} based on the technology's width table. Please check your power grid.".format(dw=str(width), lay=layer, fw=str(width_table[i-1])))
                     qwidth = width_table[i-1]
                     break
         return qwidth
 
-    def get_width_spacing_start_twt(self, tracks: int, logger: HammerVLSILoggingContext) -> Tuple[Decimal, Decimal, Decimal]:
+    def get_width_spacing_start_twt(self, tracks: int, logger: Optional[HammerVLSILoggingContext]) -> Tuple[Decimal, Decimal, Decimal]:
         """
         This method will return the maximum width a wire can be in order
         to consume a given number of routing tracks.
@@ -312,7 +313,7 @@ class Metal(NamedTuple('Metal', [
         start = self.min_width / 2 + spacing
         return (self.quantize_to_width_table(width, self.name, logger), spacing, start)
 
-    def get_width_spacing_start_twwt(self, tracks: int, logger: HammerVLSILoggingContext, force_even: bool = False) -> Tuple[Decimal, Decimal, Decimal]:
+    def get_width_spacing_start_twwt(self, tracks: int, logger: Optional[HammerVLSILoggingContext], force_even: bool = False) -> Tuple[Decimal, Decimal, Decimal]:
         """
         This method will return the maximum width a wire can be in order
         to consume a given number of routing tracks.

--- a/src/hammer-tech/stackup.py
+++ b/src/hammer-tech/stackup.py
@@ -9,6 +9,7 @@
 from enum import Enum
 from typing import List, NamedTuple, Tuple, Dict
 from hammer_utils import reverse_dict, coerce_to_grid
+from hammer_logging import HammerVLSILoggingContext
 from decimal import Decimal
 from functools import partial
 
@@ -96,6 +97,15 @@ class WidthSpacingTuple(NamedTuple('WidthSpacingTuple', [
             current_spacing = wst.min_spacing
         return out
 
+class WidthTableEntry(dict):
+    """
+    An allowable wire width from technology LEF width table
+    """
+    __slots__ = ()
+
+    @staticmethod
+    def from_list(grid_unit: Decimal, l: List[dict]) -> List[Decimal]:
+        return sorted([coerce_to_grid(w["width"], grid_unit) for w in l])
 
 class Metal(NamedTuple('Metal', [
         ('name', str),
@@ -106,6 +116,7 @@ class Metal(NamedTuple('Metal', [
         ('pitch', Decimal),
         ('offset', Decimal),
         ('power_strap_widths_and_spacings', List[WidthSpacingTuple]),
+        ('power_strap_width_table', List[Decimal]),
         # Note: grid_unit is not currently parsed as part of the Metal data structure!
         # See #379
         ('grid_unit', Decimal)
@@ -126,6 +137,8 @@ class Metal(NamedTuple('Metal', [
             (0 = first track is on an axis).
     power_strap_widths_and_spacings: A list of WidthSpacingTuples that specify the minimum
                                      spacing rules for an infinitely long wire of variying width.
+    power_strap_width_table: A list of allowed metal widths in the technology.
+                             Widths smaller than the last number must be quantized to a value in the table.
     grid_unit: The fixed-point decimal value of a minimum grid unit (e.g. 1nm = 0.001).
                For most technologies, this comes from the technology plugin and is the same for all layers.
     """
@@ -134,10 +147,10 @@ class Metal(NamedTuple('Metal', [
     @staticmethod
     def from_setting(grid_unit: Decimal, d: dict) -> "Metal":
         """
-        Return a Metal object from a dict with keys "name", "index", "direction", "min_width", "max_width", "pitch", "offset", and "power_strap_widths_and_spacings"
+        Return a Metal object from a dict with keys "name", "index", "direction", "min_width", "max_width", "pitch", "offset", "power_strap_widths_and_spacings", and "power_strap_width_table"
 
         :param grid_unit: The manufacturing grid unit in um
-        :param d: A dict containing the keys "name", "index", "direction", "min_width", "max_width", "pitch", "offset", and "power_strap_widths_and_spacings"
+        :param d: A dict containing the keys "name", "index", "direction", "min_width", "max_width", "pitch", "offset", "power_strap_widths_and_spacings", and "power_strap_width_table"
         """
         return Metal(
             grid_unit=grid_unit,
@@ -148,7 +161,8 @@ class Metal(NamedTuple('Metal', [
             max_width=coerce_to_grid(d["max_width"] if "max_width" in d and d["max_width"] else 0.0, grid_unit),
             pitch=coerce_to_grid(d["pitch"], grid_unit),
             offset=coerce_to_grid(d["offset"], grid_unit),
-            power_strap_widths_and_spacings=WidthSpacingTuple.from_list(grid_unit, d["power_strap_widths_and_spacings"])
+            power_strap_widths_and_spacings=WidthSpacingTuple.from_list(grid_unit, d["power_strap_widths_and_spacings"]),
+            power_strap_width_table=WidthTableEntry.from_list(grid_unit, d["power_strap_width_table"] if "power_strap_width_table" in d and d["power_strap_width_table"] else [])
         )
 
     def get_spacing_for_width(self, width: Decimal) -> Decimal:
@@ -225,7 +239,35 @@ class Metal(NamedTuple('Metal', [
         """
         return self.min_spacing_and_max_width_from_pitch(pitch)[1]
 
-    def get_width_spacing_start_twt(self, tracks: int) -> Tuple[Decimal, Decimal, Decimal]:
+    def quantize_to_width_table(self, width: Decimal, layer: str, logger: HammerVLSILoggingContext) -> Decimal:
+        """
+        Compare a desired width to the width table, if specified for a technology.
+        Will return the allowable width smaller than or equal to the desired width,
+        except if the desired width is greater than or equal to the last width in the width table.
+        Issues a logger warning for the user if the returned width was quantized.
+        """
+        width_table = self.power_strap_width_table
+        if width_table == []:
+            qwidth = width
+        else:
+            for i,w in enumerate(width_table):
+                if width > w:
+                    # last entry in table is special, width can be greater than or equal to this number
+                    if i == len(width_table)-1:
+                        qwidth = width
+                        break
+                    else:
+                        continue
+                elif width == w:
+                    qwidth = w
+                    break
+                else:
+                    logger.warning("The desired power strap width {dw} on {lay} was quantized down to {fw} based on the technology's width table. Please check your power grid.".format(dw=str(width), lay=layer, fw=str(width_table[i-1])))
+                    qwidth = width_table[i-1]
+                    break
+        return qwidth
+
+    def get_width_spacing_start_twt(self, tracks: int, logger: HammerVLSILoggingContext) -> Tuple[Decimal, Decimal, Decimal]:
         """
         This method will return the maximum width a wire can be in order
         to consume a given number of routing tracks.
@@ -268,9 +310,9 @@ class Metal(NamedTuple('Metal', [
         assert int(width / self.grid_unit) % 2 == 0, (
             "This calculation should always produce an even width")
         start = self.min_width / 2 + spacing
-        return (width, spacing, start)
+        return (self.quantize_to_width_table(width, self.name, logger), spacing, start)
 
-    def get_width_spacing_start_twwt(self, tracks: int, force_even: bool = False) -> Tuple[Decimal, Decimal, Decimal]:
+    def get_width_spacing_start_twwt(self, tracks: int, logger: HammerVLSILoggingContext, force_even: bool = False) -> Tuple[Decimal, Decimal, Decimal]:
         """
         This method will return the maximum width a wire can be in order
         to consume a given number of routing tracks.
@@ -308,7 +350,7 @@ class Metal(NamedTuple('Metal', [
         if force_even and int(width / self.grid_unit) % 2 == 1:
             width = width - self.grid_unit
             start = start + self.grid_unit
-        return (width, spacing, start)
+        return (self.quantize_to_width_table(width, self.name, logger), spacing, start)
 
     # TODO implement M W X* W M style wires, where X is slightly narrower than W and centered on-grid
 

--- a/src/hammer-tech/stackup.py
+++ b/src/hammer-tech/stackup.py
@@ -99,7 +99,7 @@ class WidthSpacingTuple(NamedTuple('WidthSpacingTuple', [
 
 class WidthTableEntry(dict):
     """
-    An allowable wire width from technology LEF width table
+    An allowable wire width from technology LEF width table.
     """
     __slots__ = ()
 
@@ -247,7 +247,7 @@ class Metal(NamedTuple('Metal', [
         Issues a logger warning for the user if the returned width was quantized.
         """
         width_table = self.power_strap_width_table
-        if width_table == []:
+        if len(width_table) == 0:
             qwidth = width
         else:
             for i,w in enumerate(width_table):

--- a/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py
@@ -667,13 +667,16 @@ class HammerPlaceAndRouteTool(HammerTool):
                 spacing, width = layer.min_spacing_and_max_width_from_pitch(one_strap_pitch)
                 strap_start = spacing / 2 + layer.offset
             else:
-                width, spacing, strap_start = layer.get_width_spacing_start_twwt(track_width, force_even=True)
+                width, spacing, strap_start = layer.get_width_spacing_start_twwt(track_width, force_even=True, logger=self.logger.context(layer_name))
         else:
-            width, spacing, strap_start = layer.get_width_spacing_start_twt(track_width)
+            width, spacing, strap_start = layer.get_width_spacing_start_twt(track_width, logger=self.logger.context(layer_name))
             spacing = 2*spacing + (track_spacing - 1) * layer.pitch + layer.min_width
         offset = track_offset + track_start * layer.pitch + strap_start
         assert width > Decimal(0), "Width must be greater than zero. You probably have a malformed tech plugin on layer {}.".format(layer_name)
         assert spacing > Decimal(0), "Spacing must be greater than zero. You probably have a malformed tech plugin on layer {}.".format(layer_name)
+        density = Decimal(len(nets)) * width / pitch * Decimal(100)
+        if density > Decimal(85):
+            self.logger.warning("CAUTION! Your {layer} power strap density is {density}%. Check your technology's DRM to see if this violates maximum density rules.".format(layer=layer_name, density=density))
         return self.specify_power_straps(layer_name, bottom_via_layer, blockage_spacing, pitch, width, spacing, offset, bbox, nets, add_pins)
 
     def specify_all_power_straps_by_tracks(self, layer_names: List[str], ground_net: str, power_nets: List[str], power_weights: List[int], bbox: Optional[List[Decimal]], pin_layers: List[str]) -> List[str]:

--- a/src/hammer-vlsi/tech_test.py
+++ b/src/hammer-vlsi/tech_test.py
@@ -650,6 +650,37 @@ END LIBRARY
         self.assertEqual(tech.get_lvs_decks_for_tool("chisel"),
                 [LVSDeck(tool_name="chisel", name="some_wood", path="/path/to/chisel/some_wood.lvs.rules")])
 
+    def test_stackup(self) -> None:
+        """
+        Test that getting the stackup works as expected.
+        """
+        import hammer_config
+
+        tech_dir, tech_dir_base = HammerToolTestHelpers.create_tech_dir("dummy28")
+        tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
+
+        test_stackup = StackupTestHelper.create_test_stackup_dict(10)
+
+        def add_stackup(in_dict: Dict[str, Any]) -> Dict[str, Any]:
+            out_dict = deepdict(in_dict)
+            out_dict.update({"stackups": [test_stackup]})
+            return out_dict
+
+        HammerToolTestHelpers.write_tech_json(tech_json_filename, add_stackup)
+        tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
+        tech.cache_dir = tech_dir
+
+        tool = DummyTool()
+        tool.technology = tech
+        database = hammer_config.HammerDatabase()
+        tool.set_database(database)
+
+        self.assertEqual(
+            tech.get_stackup_by_name(test_stackup["name"]),
+            Stackup.from_setting(tech.get_grid_unit(), test_stackup)
+        )
+
+
 class StackupTestHelper:
 
     @staticmethod
@@ -680,12 +711,12 @@ class StackupTestHelper:
         return wst
 
     @staticmethod
-    def create_w_tbl(index: int, entries: int) -> List[Dict[str, float]]:
+    def create_w_tbl(index: int, entries: int) -> List[float]:
+        """
+        Create a width table (power_strap_width_table).
+        """
         min_w = StackupTestHelper.index_to_min_width_fn(index)
-        w_tbl = []
-        for x in range(1, 4*entries+1, 4):
-            w_tbl.append({"width": min_w*x})
-        return w_tbl
+        return list(map(lambda x: min_w*x, range(1, 4 * entries + 1, 4)))
 
     @staticmethod
     def create_test_metal(index: int) -> Dict[str, Any]:
@@ -721,7 +752,7 @@ class StackupTestHelper:
     @staticmethod
     def create_test_stackup_list() -> List["Stackup"]:
         output = []
-        for x in range(5,8):
+        for x in range(5, 8):
             output.append(Stackup.from_setting(StackupTestHelper.mfr_grid(), StackupTestHelper.create_test_stackup_dict(x)))
             for m in output[-1].metals:
                 assert m.grid_unit == StackupTestHelper.mfr_grid(), "FIXME: the unit grid is different between the tests and metals"
@@ -730,13 +761,28 @@ class StackupTestHelper:
 
 class StackupTest(unittest.TestCase):
     """
-    Tests for the Stackup APIs in stackup.py
+    Tests for the stackup APIs in stackup.py.
     """
 
-    # Test that a T W T wire is correctly sized
-    # This will pass if the wide wire does not have a spacing DRC violation to surrounding minimum-sized wires and is within a single unit grid
-    # This method is not allowed to round the wire, so simply adding a manufacturing grid should suffice to "fail" DRC
+    def test_wire_parsing_from_json(self) -> None:
+        """
+        Test that wires can be parsed correctly from JSON.
+        """
+        grid_unit = StackupTestHelper.mfr_grid()
+        metal_dict = StackupTestHelper.create_test_metal(3)  # type: Dict[str, Any]
+        direct_metal = Metal.from_setting(grid_unit, StackupTestHelper.create_test_metal(3))  # type: Metal
+        json_string = json.dumps(metal_dict, cls=HammerJSONEncoder)  # type: str
+        json_metal = Metal.from_setting(grid_unit, json.loads(json_string))  # type: Metal
+        self.assertTrue(direct_metal, json_metal)
+
     def test_twt_wire(self) -> None:
+        """
+        Test that a T W T wire is correctly sized.
+        This will pass if the wide wire does not have a spacing DRC violation
+        to surrounding minimum-sized wires and is within a single unit grid.
+        This method is not allowed to round the wire, so simply adding a
+        manufacturing grid should suffice to "fail" DRC.
+        """
         # Generate multiple stackups, but we'll only use the largest for this test
         stackup = StackupTestHelper.create_test_stackup_list()[-1]
         for m in stackup.metals:
@@ -762,10 +808,14 @@ class StackupTest(unittest.TestCase):
                 s = m.get_spacing_for_width(w)
                 self.assertLess(m.pitch * (num_tracks + 1), m.min_width + s*2 + w)
 
-    # Test that a T W W T wire is correctly sized
-    # This will pass if the wide wire does not have a spacing DRC violation to surrounding minimum-sized wires and is within a single unit grid
-    # This method is not allowed to round the wire, so simply adding a manufacturing grid should suffice to "fail" DRC
     def test_twwt_wire(self) -> None:
+        """
+        Test that a T W W T wire is correctly sized.
+        This will pass if the wide wire does not have a spacing DRC violation
+        to surrounding minimum-sized wires and is within a single unit grid.
+        This method is not allowed to round the wire, so simply adding a
+        manufacturing grid should suffice to "fail" DRC.
+        """
         # Generate multiple stackups, but we'll only use the largest for this test
         stackup = StackupTestHelper.create_test_stackup_list()[-1]
         for m in stackup.metals:

--- a/src/hammer-vlsi/tech_test.py
+++ b/src/hammer-vlsi/tech_test.py
@@ -741,7 +741,7 @@ class StackupTest(unittest.TestCase):
         stackup = StackupTestHelper.create_test_stackup_list()[-1]
         for m in stackup.metals:
             # Try with 1 track (this should return a minimum width wire)
-            w, s, o = m.get_width_spacing_start_twt(1)
+            w, s, o = m.get_width_spacing_start_twt(1, logger=None)
             self.assertEqual(w, m.min_width)
             self.assertEqual(s, m.pitch - w)
 
@@ -752,7 +752,7 @@ class StackupTest(unittest.TestCase):
             # | | | | | |
             # T  --W--  T
             for num_tracks in range(2,40):
-                w, s, o = m.get_width_spacing_start_twt(num_tracks)
+                w, s, o = m.get_width_spacing_start_twt(num_tracks, logger=None)
                 # Check that the resulting spacing is the min spacing
                 self.assertTrue(s >= m.get_spacing_for_width(w))
                 # Check that there is no DRC
@@ -770,7 +770,7 @@ class StackupTest(unittest.TestCase):
         stackup = StackupTestHelper.create_test_stackup_list()[-1]
         for m in stackup.metals:
             # Try with 1 track (this should return a minimum width wire)
-            w, s, o = m.get_width_spacing_start_twwt(1)
+            w, s, o = m.get_width_spacing_start_twwt(1, logger=None)
             self.assertEqual(w, m.min_width)
             self.assertEqual(s, m.pitch - w)
 
@@ -781,7 +781,7 @@ class StackupTest(unittest.TestCase):
             # | | | | | | | | | |
             # T  --W--   --W--  T
             for num_tracks in range(2,40):
-                w, s, o = m.get_width_spacing_start_twwt(num_tracks)
+                w, s, o = m.get_width_spacing_start_twwt(num_tracks, logger=None)
                 # Check that the resulting spacing is the min spacing
                 self.assertGreaterEqual(s, m.get_spacing_for_width(w))
                 # Check that there is no DRC

--- a/src/hammer-vlsi/tech_test.py
+++ b/src/hammer-vlsi/tech_test.py
@@ -680,6 +680,14 @@ class StackupTestHelper:
         return wst
 
     @staticmethod
+    def create_w_tbl(index: int) -> List[Dict[str, float]]:
+        min_w = StackupTestHelper.index_to_min_width_fn(index)
+        w_tbl = []
+        # Tests currently don't check against quantized widths
+        w_tbl.append({"width": min_w})
+        return w_tbl
+
+    @staticmethod
     def create_test_metal(index: int) -> Dict[str, Any]:
         output = {} # type: Dict[str, Any]
         output["name"] = "M{}".format(index)
@@ -689,6 +697,7 @@ class StackupTestHelper:
         output["pitch"] = StackupTestHelper.index_to_min_pitch_fn(index)
         output["offset"] = StackupTestHelper.index_to_offset_fn(index)
         output["power_strap_widths_and_spacings"] = StackupTestHelper.create_wst_list(index)
+        output["power_strap_width_table"] = StackupTestHelper.create_w_tbl(index)
         return output
 
     @staticmethod

--- a/src/hammer-vlsi/tech_test.py
+++ b/src/hammer-vlsi/tech_test.py
@@ -874,6 +874,7 @@ class StackupTest(unittest.TestCase):
     def test_quantize_to_width_table(self) -> None:
         # Generate two metals (index 1) and add more entries to width table of one of them
         # Only 0.05, 0.25, 0.45, 0.65, 0.85+ allowed -> check quantization against metal without width table
+        # TODO: improve this behaviour in a future PR
         metal_dict = StackupTestHelper.create_test_metal(1)
         metal_dict["power_strap_width_table"] = StackupTestHelper.create_w_tbl(1, 5)
         q_metal = Metal.from_setting(StackupTestHelper.mfr_grid(), metal_dict)


### PR DESCRIPTION
First attempt at fixing #497 & #502

Optional tech schema for quantized wire widths (LEF58_WIDTHTABLE)
- Checks desired strap width against provided table
- Quantizes down, except for highest value in table, for which all widths at least that one are allowed
- Issues logger warning if quantization happened (I don't like how I implemented this)

Simple check for strap density (sum of widths/pitch), warns if over 85%.