### PR TITLE
fixes #476, json now equal with yml

### DIFF
--- a/src/hammer-vlsi/hammer_vlsi/cli_driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/cli_driver.py
@@ -1089,7 +1089,7 @@ class CLIDriver:
         parser.add_argument("-e", "--environment_config", action='append', required=False,
                             help="Environment config files (.yml or .json) - .json will take precendence over any .yml. These config files will not be re-emitted in the output json. Can also be specified as a colon-separated list in the environment variable HAMMER_ENVIRONMENT_CONFIGS.")
         parser.add_argument("-p", "--project_config", action='append', dest="configs", type=str,
-                            help='Project config files (.yml or .json) - .json will take precedence over any .yml.')
+                            help='Project config files (.yml or .json).')
         parser.add_argument("-l", "--log", required=False,
                             help='Log file. Leave blank to automatically create one.')
         parser.add_argument("--obj_dir", required=False,

--- a/src/hammer-vlsi/hammer_vlsi/driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/driver.py
@@ -31,7 +31,7 @@ __all__ = ['HammerDriverOptions', 'HammerDriver']
 HammerDriverOptions = NamedTuple('HammerDriverOptions', [
     # List of environment config files in .json
     ('environment_configs', List[str]),
-    # List of project config files in .json
+    # List of project config files in .json or .yml
     ('project_configs', List[str]),
     # Log file location.
     ('log_file', str),

--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -955,13 +955,14 @@ def load_config_from_paths(config_paths: Iterable[str], strict: bool = False) ->
 def load_config_from_defaults(path: str, strict: bool = False) -> List[dict]:
     """
     Load the default configuration for a hammer-vlsi tool/library/technology in
-    the given path, which consists of defaults.yml and defaults.json.
+    the given path, which consists of defaults.yml and defaults.json (with
+    defaults.json taking priority).
 
     :param config_paths: Path to defaults.yml and defaults.json.
     :param strict: Set to true to error if the file is not found.
     :return: A list of configs in order of specification.
     """
     return load_config_from_paths([
-        os.path.join(path, "defaults.yml"),
-        os.path.join(path, "defaults.json")
+        os.path.join(path, "defaults.json"),
+        os.path.join(path, "defaults.yml")
     ])

--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -944,6 +944,7 @@ def combine_configs(configs: Iterable[dict]) -> dict:
 def load_config_from_paths(config_paths: Iterable[str], strict: bool = False) -> List[dict]:
     """
     Load configuration from paths containing \*.yml and \*.json files.
+    Files specified later in the list take precedence (see combine_configs).
 
     :param config_paths: Path to \*.yml and \*.json config files.
     :param strict: Set to true to error if the file is not found.

--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -944,28 +944,22 @@ def combine_configs(configs: Iterable[dict]) -> dict:
 def load_config_from_paths(config_paths: Iterable[str], strict: bool = False) -> List[dict]:
     """
     Load configuration from paths containing \*.yml and \*.json files.
-    As noted in README.config, .json will take precedence over .yml files.
 
     :param config_paths: Path to \*.yml and \*.json config files.
     :param strict: Set to true to error if the file is not found.
-    :return: A list of configs in increasing order of precedence.
+    :return: A list of configs in order of specification.
     """
-    # Put the .json configs after the .yml configs to make sure .json takes
-    # precedence over .yml.
-    sorted_paths = sorted(config_paths, key=lambda x: x.endswith(".json"))
-
-    return list(map(lambda path: load_config_from_file(path, strict), sorted_paths))
+    return list(map(lambda path: load_config_from_file(path, strict), config_paths))
 
 
 def load_config_from_defaults(path: str, strict: bool = False) -> List[dict]:
     """
     Load the default configuration for a hammer-vlsi tool/library/technology in
-    the given path, which consists of defaults.yml and defaults.json (with
-    defaults.json taking priority).
+    the given path, which consists of defaults.yml and defaults.json.
 
     :param config_paths: Path to defaults.yml and defaults.json.
     :param strict: Set to true to error if the file is not found.
-    :return: A list of configs in increasing order of precedence.
+    :return: A list of configs in order of specification.
     """
     return load_config_from_paths([
         os.path.join(path, "defaults.yml"),


### PR DESCRIPTION
Please comment if you think there's a philosophical reason to keep this, otherwise it blocks some functionality because one cannot just `-p` another yml with small settings changes, e.g. when doing a `make redo-par` that takes the `par-output-full.json`.