### PR TITLE
make special cells return None if not defined in tech plugin

### DIFF
--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -974,7 +974,7 @@ class HammerTechnology:
             cell_list = [SpecialCell.from_setting(sc) for sc in list(self.config.special_cells)]
             return [fc for fc in cell_list if fc.cell_type == cell_type]
         else:
-            return None
+            return []
 
     def get_grid_unit(self) -> Decimal:
         """

--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -974,7 +974,7 @@ class HammerTechnology:
             cell_list = [SpecialCell.from_setting(sc) for sc in list(self.config.special_cells)]
             return [fc for fc in cell_list if fc.cell_type == cell_type]
         else:
-            raise ValueError("Tech JSON does not specify any special cells")
+            return None
 
     def get_grid_unit(self) -> Decimal:
         """


### PR DESCRIPTION
This is meant to make it so the tech plugin does not have to use the special cells API.  The special cells API is currently pretty simple and would typically be overridden by a hook, so I think it is better to allow the user to not define any special cells in the tech plugin if they plan on using a hook anyways.