### PR TITLE
Check invalid tarballs

### DIFF
--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -712,6 +712,9 @@ class HammerTechnology:
         for tarball in self.config.tarballs:
             target_path = os.path.join(self.extracted_tarballs_dir, tarball.path)
             tarball_path = os.path.join(self.get_setting(tarball.base_var), tarball.path)
+            if not os.path.isfile(tarball_path):
+                raise ValueError("Path {0} does not point to a valid tarball!".format(tarball_path))
+                continue
             if os.path.isdir(target_path):
                 # If the folder already seems to exist, continue
                 continue

--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -714,7 +714,6 @@ class HammerTechnology:
             tarball_path = os.path.join(self.get_setting(tarball.base_var), tarball.path)
             if not os.path.isfile(tarball_path):
                 raise ValueError("Path {0} does not point to a valid tarball!".format(tarball_path))
-                continue
             if os.path.isdir(target_path):
                 # If the folder already seems to exist, continue
                 continue


### PR DESCRIPTION
Addresses a small issue that came up where tech cache was created despite an invalid tarball was specified, so it skipped the post-extraction hacking for ASAP7.