### PR TITLE
Bad logging when --to_step used

### DIFF
--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -590,7 +590,7 @@ class HammerTool(metaclass=ABCMeta):
 
             if not pause_step_pre and pause_step == step.name:
                 self.logger.info("Pausing tool execution after '{step}' due to pause hook".format(step=step.name))
-                for s in new_steps[step_index:]:
+                for s in new_steps[step_index+1:]:
                     self.logger.debug("Sub-step '{step}' skipped due to pause hook".format(step=s.name))
                 break
 

--- a/src/hammer-vlsi/test.py
+++ b/src/hammer-vlsi/test.py
@@ -993,6 +993,21 @@ class HammerToolHooksTest(unittest.TestCase):
                 else:
                     self.assertEqual(self.read(file), "step{}".format(i))
 
+    def test_pause_hooks_logging(self) -> None:
+        """Test that pause hooks log correctly."""
+        with self.create_context() as c:
+            with HammerLoggingCaptureContext() as c2:
+                success, syn_output = c.driver.run_synthesis(hook_actions=[
+                    hammer_vlsi.HammerTool.make_post_pause_hook("step1")
+                ])
+                self.assertTrue(success)
+
+            # step2 to step4 should show up in log as skipped
+            for i in range(2, 5):
+                self.assertTrue(c2.log_contains("Sub-step 'step{}' skipped due to pause hook".format(i)))
+            # step1 should NOT show up in log as skipped
+            self.assertFalse(c2.log_contains("Sub-step 'step1' skipped due to pause hook"))
+
     def test_extra_pause_hooks(self) -> None:
         """Test that extra pause hooks cause an error."""
         with self.create_context() as c:


### PR DESCRIPTION
Minor quality of life typo: it printed out `Sub-step 'step' skipped due to pause hook` despite having actually run it when you specified a `--to_step`.