### PR TITLE
Move nonstandard language out of license to readme.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,5 @@
 Copyright (c) 2017-2019, The Regents of the University of California (Regents) and other contributors. All rights reserved.
 
-The list of contributors can be found in the Git history of the project, or online at https://github.com/ucb-bar/hammer/graphs/contributors
-
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 

--- a/README.md
+++ b/README.md
@@ -20,5 +20,6 @@ Useful documentation for how an example block is pushed through the VLSI flow wi
 
 History
 =======
+The list of contributors can be found in the Git history of the project, or online at https://github.com/ucb-bar/hammer/graphs/contributors
 
 The Hammer project builds upon the legacy of the [PLSI project by Palmer Dabbelt](https://www2.eecs.berkeley.edu/Pubs/TechRpts/2017/EECS-2017-77.html), a previous project which aimed to build a portable VLSI flow. The Hammer project is grateful for the feedback and lessons learned which provided valuable insight that ultimately led to the design and software architecture of Hammer as it is now.


### PR DESCRIPTION
Hopefully this will allow github's auto-detection feature correctly
identify the 3-clause BSD license we use. Fixing #557

I made this change after comparing our license file to the text here: https://choosealicense.com/licenses/bsd-3-clause/

I'm not sure if we can test this on a branch or not. I'm also unsure how often the auto-detection is run.