### PR TITLE
Cap table support

### DIFF
--- a/src/hammer-tech/filters.py
+++ b/src/hammer-tech/filters.py
@@ -129,6 +129,21 @@ class LibraryFilterHolder:
                                  paths_func=paths_func, is_file=True)
 
     @property
+    def cap_table_filter(self) -> LibraryFilter:
+        """
+        Selecting cap table RC Corner tech files.
+        """
+
+        def paths_func(lib: "Library") -> List[str]:
+            if lib.cap_table_file is not None:
+                return [lib.cap_table_file]
+            else:
+                return []
+
+        return LibraryFilter.new("cap_table", "cap table RC corner tech file",
+                                 paths_func=paths_func, is_file=True)
+
+    @property
     def verilog_synth_filter(self) -> LibraryFilter:
         """
         Selecting verilog_synth files which are synthesizable wrappers (e.g. for SRAM) which are needed in some

--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -811,7 +811,7 @@ class HammerTechnology:
         # Next, extract paths and prepend them to get the real paths.
         def get_and_prepend_path(lib: Library) -> Tuple[Library, List[str]]:
             paths = filt.paths_func(lib)
-            full_paths = list(map(lambda path: self.prepend_dir_path(path, lib), paths))
+            full_paths = list(map(lambda path: self.prepend_dir_path(path, lib) if path else '', paths))
             return lib, full_paths
 
         libs_and_paths = list(map(get_and_prepend_path, filtered_libs))  # type: List[Tuple[Library, List[str]]]

--- a/src/hammer-tech/schema.json
+++ b/src/hammer-tech/schema.json
@@ -116,6 +116,9 @@
           "qrc techfile" : {
             "type" : "string"
           },
+          "cap table file" : {
+            "type" : "string"
+          },
           "supplies" : {
             "title" : "Supplies",
             "type" : "object",


### PR DESCRIPTION
This allows for specifying a "cap table file" in the tech.json for older technologies that do not come with a qrc techfile. There should not be any issue with supplying both a cap table file and qrc tech file. The tool should always prioritize the qrc tech file. I also edited the function "get_and_prepend_path" inside the "process_library_filter" function so that if an empty path is retrieved from the tech.json then an empty string will be returned. This behavior appears to have already been expected in the "get_mmmc_qrc" function.