### PR TITLE
Use the standard output convention for sims

### DIFF
--- a/src/hammer-vlsi/generate_properties.py
+++ b/src/hammer-vlsi/generate_properties.py
@@ -202,7 +202,10 @@ def main(args) -> int:
                                   InterfaceVar("seq_cells", "str", "path to collection of all sequential standard cells in design"),
                                   InterfaceVar("sdf_file", "Optional[str]", "optional SDF file needed for timing annotated gate level sims")
                               ],
-                              outputs=[]
+                              outputs=[
+                                  InterfaceVar("output_waveforms", "List[str]", "paths to output waveforms"),
+                                  InterfaceVar("output_saifs", "List[str]", "paths to output activity files")
+                              ]
                               )
     HammerPowerTool = Interface(module="HammerPowerTool",
                                 filename="hammer_vlsi/hammer_vlsi_impl.py",

--- a/src/hammer-vlsi/hammer_vlsi/driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/driver.py
@@ -1056,13 +1056,11 @@ class HammerDriver:
                  or None if output_dict was invalid
         """
         try:
-            if "sim.outputs.waveforms" not in output_dict:
-                waveforms = []  # type: List[str]
-            else:
-                waveforms = deeplist(output_dict["sim.outputs.waveforms"])
             result = {
-                "power.inputs.waveforms": waveforms,
+                "power.inputs.waveforms": output_dict["sim.outputs.waveforms"],
                 "power.inputs.waveforms_meta": "append",
+                "power.inputs.saifs": output_dict["sim.outputs.saifs"],
+                "power.inputs.saifs_meta": "append",
                 "vlsi.builtins.is_complete": False
             }  # type: Dict[str, Any]
             return result

--- a/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_vlsi_impl.py
@@ -1138,6 +1138,8 @@ class HammerSimTool(HammerTool):
     # No current sim outputs, but some will be added
     def export_config_outputs(self) -> Dict[str, Any]:
         outputs = deepdict(super().export_config_outputs())
+        outputs["sim.outputs.waveforms"] = self.output_waveforms
+        outputs["sim.outputs.saifs"] = self.output_saifs
         return outputs
 
     @property
@@ -1257,6 +1259,46 @@ class HammerSimTool(HammerTool):
 
 
     ### Outputs ###
+
+    @property
+    def output_waveforms(self) -> List[str]:
+        """
+        Get the paths to output waveforms.
+
+        :return: The paths to output waveforms.
+        """
+        try:
+            return self.attr_getter("_output_waveforms", None)
+        except AttributeError:
+            raise ValueError("Nothing set for the paths to output waveforms yet")
+
+    @output_waveforms.setter
+    def output_waveforms(self, value: List[str]) -> None:
+        """Set the paths to output waveforms."""
+        if not (isinstance(value, List)):
+            raise TypeError("output_waveforms must be a List[str]")
+        self.attr_setter("_output_waveforms", value)
+
+
+    @property
+    def output_saifs(self) -> List[str]:
+        """
+        Get the paths to output activity files.
+
+        :return: The paths to output activity files.
+        """
+        try:
+            return self.attr_getter("_output_saifs", None)
+        except AttributeError:
+            raise ValueError("Nothing set for the paths to output activity files yet")
+
+    @output_saifs.setter
+    def output_saifs(self, value: List[str]) -> None:
+        """Set the paths to output activity files."""
+        if not (isinstance(value, List)):
+            raise TypeError("output_saifs must be a List[str]")
+        self.attr_setter("_output_saifs", value)
+
     ### END Generated interface HammerSimTool ###
     ### Generated interface HammerSimTool ###
 


### PR DESCRIPTION
SimTools can now produce SAIFs automatically and this
also lays the groundwork for SimTools to produce waveforms automatically in the future

This facilitates running the sim->power automatically.