### PR TITLE
Make sourceme.sh set HAMMER_HOME to its root dir by default

### DIFF
--- a/sourceme.sh
+++ b/sourceme.sh
@@ -6,9 +6,9 @@ if [ -z "${HAMMER_HOME}" ]; then
   #  https://stackoverflow.com/questions/59895/how-to-get-the-source-directory-of-a-bash-script-from-within-the-script-itself
   #  https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source
   export HAMMER_HOME="$( dirname "$( readlink -f "${BASH_SOURCE[0]}" )" )"
-  >&2 echo "Using (default) HAMMER_HOME=${HAMMER_HOME}"
+  >&2 echo "Using (guessed) HAMMER_HOME=${HAMMER_HOME}"
 else
-  >&2 echo "Using HAMMER_HOME=${HAMMER_HOME}"
+  >&2 echo "Using (existing) HAMMER_HOME=${HAMMER_HOME}"
 fi
 
 export HAMMER_VLSI="${HAMMER_HOME}/src/hammer-vlsi"

--- a/sourceme.sh
+++ b/sourceme.sh
@@ -6,9 +6,7 @@ if [ -z "${HAMMER_HOME}" ]; then
   #  https://stackoverflow.com/questions/59895/how-to-get-the-source-directory-of-a-bash-script-from-within-the-script-itself
   #  https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source
   export HAMMER_HOME="$( dirname "$( readlink -f "${BASH_SOURCE[0]}" )" )"
-  >&2 echo "Using (guessed) HAMMER_HOME=${HAMMER_HOME}"
-else
-  >&2 echo "Using (existing) HAMMER_HOME=${HAMMER_HOME}"
+  >&2 echo "Setting HAMMER_HOME=${HAMMER_HOME}"
 fi
 
 export HAMMER_VLSI="${HAMMER_HOME}/src/hammer-vlsi"

--- a/sourceme.sh
+++ b/sourceme.sh
@@ -1,10 +1,24 @@
 #!/bin/sh
 # Convenience script for setting variables for in-tree use of hammer.
-if [ -z "$HAMMER_HOME" ]; then
-    >&2 echo "Must set HAMMER_HOME to root. Try export HAMMER_HOME="\$PWD" for the current dir."
+
+if [ -z "${HAMMER_HOME}" ]; then
+  # Try to find the location of the script even if it's called through a symlink.
+  #  https://stackoverflow.com/questions/59895/how-to-get-the-source-directory-of-a-bash-script-from-within-the-script-itself
+  SOURCE="${BASH_SOURCE[0]}"
+  while [ -h "${SOURCE}" ]; do
+    DIR="$( cd -P "$( dirname "${SOURCE}" )" > /dev/null 2>&1 && pwd )"
+    SOURCE="$( readlink "${SOURCE}")"
+    [[ ${SOURCE} != /* ]] && SOURCE="${DIR}/${SOURCE}"
+  done
+  DIR="$( cd -P "$( dirname "${SOURCE}" )" > /dev/null 2>&1 && pwd )"
+
+  export HAMMER_HOME="${DIR}"
+  >&2 echo "Using (default) HAMMER_HOME=${HAMMER_HOME}"
 else
-export HAMMER_VLSI="$HAMMER_HOME/src/hammer-vlsi"
-export PYTHONPATH="$HAMMER_HOME/src:$HAMMER_HOME/src/jsonschema:$HAMMER_HOME/src/python-jsonschema-objects:$HAMMER_HOME/src/hammer-tech:$HAMMER_HOME/src/hammer-vlsi:$HAMMER_HOME/src/tools/pyyaml/lib3:$PYTHONPATH"
-export MYPYPATH="$PYTHONPATH"
-export PATH="$HAMMER_HOME/src/hammer-shell:$PATH"
+  >&2 echo "Using HAMMER_HOME=${HAMMER_HOME}"
 fi
+
+export HAMMER_VLSI="${HAMMER_HOME}/src/hammer-vlsi"
+export PYTHONPATH="${HAMMER_HOME}/src:${HAMMER_HOME}/src/jsonschema:${HAMMER_HOME}/src/python-jsonschema-objects:${HAMMER_HOME}/src/hammer-tech:${HAMMER_HOME}/src/hammer-vlsi:${HAMMER_HOME}/src/tools/pyyaml/lib3:${PYTHONPATH}"
+export MYPYPATH="${PYTHONPATH}"
+export PATH="${HAMMER_HOME}/src/hammer-shell:${PATH}"

--- a/sourceme.sh
+++ b/sourceme.sh
@@ -4,15 +4,8 @@
 if [ -z "${HAMMER_HOME}" ]; then
   # Try to find the location of the script even if it's called through a symlink.
   #  https://stackoverflow.com/questions/59895/how-to-get-the-source-directory-of-a-bash-script-from-within-the-script-itself
-  SOURCE="${BASH_SOURCE[0]}"
-  while [ -h "${SOURCE}" ]; do
-    DIR="$( cd -P "$( dirname "${SOURCE}" )" > /dev/null 2>&1 && pwd )"
-    SOURCE="$( readlink "${SOURCE}")"
-    [[ ${SOURCE} != /* ]] && SOURCE="${DIR}/${SOURCE}"
-  done
-  DIR="$( cd -P "$( dirname "${SOURCE}" )" > /dev/null 2>&1 && pwd )"
-
-  export HAMMER_HOME="${DIR}"
+  #  https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source
+  export HAMMER_HOME="$( dirname "$( readlink -f "${BASH_SOURCE[0]}" )" )"
   >&2 echo "Using (default) HAMMER_HOME=${HAMMER_HOME}"
 else
   >&2 echo "Using HAMMER_HOME=${HAMMER_HOME}"

--- a/sourceme.sh
+++ b/sourceme.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Convenience script for setting variables for in-tree use of hammer.
 
 if [ -z "${HAMMER_HOME}" ]; then


### PR DESCRIPTION
If no ${HAMMER_HOME} is specified, the script finds the location of itself (even if called through symlinks) and uses that as the the default.

Users who wish to set this manually can do so prior to invoking the script, as was the previous behaviour.