### PR TITLE
Error if we can't load the specified technology

### DIFF
--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -394,16 +394,16 @@ class HammerTechnology:
         :param path: Path to set as the technology folder (e.g. foo/bar/technology/asap7)
         """
 
-        # try to override tech, if __init__.py exist.
+        # Try to load the technology's __init__.py
         try:
             mod = importlib.import_module(technology_name)
-            # work around for python < 3.6
-            try:
-                tech = mod.tech # type: ignore
-            except:
-                raise ImportError # type: ignore
-        except ImportError:
-            tech = HammerTechnology()
+        except ImportError as e:
+            raise ImportError("Unable to import technology {t} due to import error:\n{i}".format(t=technology_name, i=str(e)))
+        # work around for python < 3.6
+        try:
+            tech = mod.tech # type: ignore
+        except Exception as e:
+            raise ValueError("Unable to use technology {t} due to error:\n{i}".format(t=technology_name, i=str(e)))
 
         # Name of the technology
         tech.name = technology_name

--- a/src/hammer-tech/hammer_tech.py
+++ b/src/hammer-tech/hammer_tech.py
@@ -8,6 +8,7 @@
 
 import json
 import os
+import sys
 import tarfile
 import importlib
 from abc import ABCMeta, abstractmethod
@@ -396,6 +397,9 @@ class HammerTechnology:
 
         # Try to load the technology's __init__.py
         try:
+            # We must remove any duplicates before loading. See load_tool
+            if technology_name in sys.modules:
+                del sys.modules[technology_name]
             mod = importlib.import_module(technology_name)
         except ImportError as e:
             raise ImportError("Unable to import technology {t} due to import error:\n{i}".format(t=technology_name, i=str(e)))

--- a/src/hammer-vlsi/tech_test.py
+++ b/src/hammer-vlsi/tech_test.py
@@ -12,6 +12,7 @@ import json
 import os
 import shutil
 import unittest
+import sys
 
 from hammer_vlsi import HammerVLSISettings
 from typing import Any, Dict, List, Optional
@@ -58,6 +59,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
             return out_dict
 
         HammerToolTestHelpers.write_tech_json(tech_json_filename, add_named_library)
+        sys.path.append(tech_dir_base)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -126,6 +128,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
             return out_dict
 
         HammerToolTestHelpers.write_tech_json(tech_json_filename, add_duplicates)
+        sys.path.append(tech_dir_base)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -179,6 +182,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
             }, cls=HammerJSONEncoder))
 
         HammerToolTestHelpers.write_tech_json(tech_json_filename, self.add_tarballs)
+        sys.path.append(tech_dir_base)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -212,6 +216,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
             }, cls=HammerJSONEncoder))
 
         HammerToolTestHelpers.write_tech_json(tech_json_filename, self.add_tarballs)
+        sys.path.append(tech_dir_base)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -247,6 +252,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
             }, cls=HammerJSONEncoder))
 
         HammerToolTestHelpers.write_tech_json(tech_json_filename, self.add_tarballs)
+        sys.path.append(tech_dir_base)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -351,6 +357,7 @@ class HammerTechnologyTest(HasGetTech, unittest.TestCase):
         with open(tech_json_filename, "w") as f:  # pyline: disable=invalid-name
             f.write(json.dumps(tech_json, cls=HammerJSONEncoder, indent=4))
 
+        sys.path.append(tech_dir_base)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -383,6 +390,7 @@ libraries: []
         tech_yaml_filename = os.path.join(tech_dir, "dummy28.tech.yml")
         with open(tech_yaml_filename, "w") as f:  # pylint: disable=invalid-name
             f.write(tech_yaml)
+        sys.path.append(tech_dir_base)
         tech_opt = hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir)
         self.assertFalse(tech_opt is None, "Unable to load technology")
 
@@ -404,6 +412,7 @@ libraries: []
             return out_dict
 
         HammerToolTestHelpers.write_tech_json(tech_json_filename, add_gds_map)
+        sys.path.append(tech_dir_base)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -441,6 +450,7 @@ libraries: []
 
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
         HammerToolTestHelpers.write_tech_json(tech_json_filename)
+        sys.path.append(tech_dir_base)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -471,6 +481,7 @@ libraries: []
             return out_dict
 
         HammerToolTestHelpers.write_tech_json(tech_json_filename, add_physical_only_cells_list)
+        sys.path.append(tech_dir_base)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -510,6 +521,7 @@ libraries: []
 
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
         HammerToolTestHelpers.write_tech_json(tech_json_filename)
+        sys.path.append(tech_dir_base)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -540,6 +552,7 @@ libraries: []
             return out_dict
 
         HammerToolTestHelpers.write_tech_json(tech_json_filename, add_dont_use_list)
+        sys.path.append(tech_dir_base)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -579,6 +592,7 @@ libraries: []
 
         tech_json_filename = os.path.join(tech_dir, "dummy28.tech.json")
         HammerToolTestHelpers.write_tech_json(tech_json_filename)
+        sys.path.append(tech_dir_base)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -627,6 +641,7 @@ END LIBRARY
             return r
 
         HammerToolTestHelpers.write_tech_json(tech_json_filename, add_lib_with_lef)
+        sys.path.append(tech_dir_base)
         tech_opt = hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir)
         if tech_opt is None:
             self.assertTrue(False, "Unable to load technology")
@@ -666,6 +681,7 @@ END LIBRARY
                              ]})
             return out_dict
         HammerToolTestHelpers.write_tech_json(tech_json_filename, add_special_cells)
+        sys.path.append(tech_dir_base)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -713,6 +729,7 @@ END LIBRARY
             return out_dict
 
         HammerToolTestHelpers.write_tech_json(tech_json_filename, add_drc_lvs_decks)
+        sys.path.append(tech_dir_base)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 
@@ -755,6 +772,7 @@ END LIBRARY
             return out_dict
 
         HammerToolTestHelpers.write_tech_json(tech_json_filename, add_stackup)
+        sys.path.append(tech_dir_base)
         tech = self.get_tech(hammer_tech.HammerTechnology.load_from_dir("dummy28", tech_dir))
         tech.cache_dir = tech_dir
 

--- a/src/hammer-vlsi/technology/nop/__init__.py
+++ b/src/hammer-vlsi/technology/nop/__init__.py
@@ -1,0 +1,6 @@
+from hammer_tech import HammerTechnology
+
+class NopTechnology(HammerTechnology):
+    pass
+
+tech = NopTechnology()

--- a/src/hammer-vlsi/test_tool_utils.py
+++ b/src/hammer-vlsi/test_tool_utils.py
@@ -63,6 +63,10 @@ class HammerToolTestHelpers:
         tech_dir_base = tempfile.mkdtemp()
         tech_dir = os.path.join(tech_dir_base, tech_name)
         os.mkdir(tech_dir)
+        tech_init_py = os.path.join(tech_dir, "__init__.py")
+        with open(tech_init_py, "w") as f: # pylint: disable=invalid-name
+            f.write("from hammer_tech import HammerTechnology\nclass {t}Technology(HammerTechnology):\n    pass\ntech = {t}Technology()".format(
+                t=tech_name))
 
         return tech_dir, tech_dir_base
 


### PR DESCRIPTION
I believe this code was only around to try to have a fallback in case the technology passed didn't have an `__init__.py` which I think isn't something we truly support.
This fix also allows for changes like #576 or any otherwise broken (via ImportError) tech plugins to be noticed rather than silently ignored.