### PR TITLE
Fix ASAP7 SRAM behav models

### DIFF
--- a/src/hammer-vlsi/technology/asap7/sram_compiler/memories/behavioral/sram_behav_models.v
+++ b/src/hammer-vlsi/technology/asap7/sram_compiler/memories/behavioral/sram_behav_models.v
@@ -76,7 +76,7 @@ always @ (posedge CE_i)
 		memory[A_i] = I_i;
 		
 
-always @ (data_out or OEB_i)
+always @ (posedge CE_i)
 	if (!OEB_i) 
 		O_i = data_out;
 	else
@@ -202,7 +202,7 @@ always @ (posedge CE_i)
 		memory[A_i] = I_i;
 		
 
-always @ (data_out or OEB_i)
+always @ (posedge CE_i)
 	if (!OEB_i) 
 		O_i = data_out;
 	else
@@ -330,7 +330,7 @@ always @ (posedge CE_i)
 		memory[A_i] = I_i;
 		
 
-always @ (data_out or OEB_i)
+always @ (posedge CE_i)
 	if (!OEB_i) 
 		O_i = data_out;
 	else
@@ -418,7 +418,7 @@ always @ (posedge CE_i)
 		memory[A_i] = I_i;
 		
 
-always @ (data_out or OEB_i)
+always @ (posedge CE_i)
 	if (!OEB_i) 
 		O_i = data_out;
 	else
@@ -627,7 +627,7 @@ always @ (posedge CE_i)
 		memory[A_i] = I_i;
 		
 
-always @ (data_out or OEB_i)
+always @ (posedge CE_i)
 	if (!OEB_i) 
 		O_i = data_out;
 	else
@@ -739,7 +739,7 @@ always @ (posedge CE_i)
 		memory[A_i] = I_i;
 		
 
-always @ (data_out or OEB_i)
+always @ (posedge CE_i)
 	if (!OEB_i) 
 		O_i = data_out;
 	else
@@ -865,7 +865,7 @@ always @ (posedge CE_i)
 		memory[A_i] = I_i;
 		
 
-always @ (data_out or OEB_i)
+always @ (posedge CE_i)
 	if (!OEB_i) 
 		O_i = data_out;
 	else
@@ -993,7 +993,7 @@ always @ (posedge CE_i)
 		memory[A_i] = I_i;
 		
 
-always @ (data_out or OEB_i)
+always @ (posedge CE_i)
 	if (!OEB_i) 
 		O_i = data_out;
 	else
@@ -1081,7 +1081,7 @@ always @ (posedge CE_i)
 		memory[A_i] = I_i;
 		
 
-always @ (data_out or OEB_i)
+always @ (posedge CE_i)
 	if (!OEB_i) 
 		O_i = data_out;
 	else
@@ -1211,7 +1211,7 @@ always @ (posedge CE_i)
 		memory[A_i] = I_i;
 		
 
-always @ (data_out or OEB_i)
+always @ (posedge CE_i)
 	if (!OEB_i) 
 		O_i = data_out;
 	else
@@ -1419,7 +1419,7 @@ always @ (posedge CE_i)
 		memory[A_i] = I_i;
 		
 
-always @ (data_out or OEB_i)
+always @ (posedge CE_i)
 	if (!OEB_i) 
 		O_i = data_out;
 	else
@@ -1531,7 +1531,7 @@ always @ (posedge CE_i)
 		memory[A_i] = I_i;
 		
 
-always @ (data_out or OEB_i)
+always @ (posedge CE_i)
 	if (!OEB_i) 
 		O_i = data_out;
 	else
@@ -1619,7 +1619,7 @@ always @ (posedge CE_i)
 		memory[A_i] = I_i;
 		
 
-always @ (data_out or OEB_i)
+always @ (posedge CE_i)
 	if (!OEB_i) 
 		O_i = data_out;
 	else
@@ -1827,7 +1827,7 @@ always @ (posedge CE_i)
 		memory[A_i] = I_i;
 		
 
-always @ (data_out or OEB_i)
+always @ (posedge CE_i)
 	if (!OEB_i) 
 		O_i = data_out;
 	else
@@ -1939,7 +1939,7 @@ always @ (posedge CE_i)
 		memory[A_i] = I_i;
 		
 
-always @ (data_out or OEB_i)
+always @ (posedge CE_i)
 	if (!OEB_i) 
 		O_i = data_out;
 	else
@@ -2053,7 +2053,7 @@ always @ (posedge CE_i)
 		memory[A_i] = I_i;
 		
 
-always @ (data_out or OEB_i)
+always @ (posedge CE_i)
 	if (!OEB_i) 
 		O_i = data_out;
 	else
@@ -2141,7 +2141,7 @@ always @ (posedge CE_i)
 		memory[A_i] = I_i;
 		
 
-always @ (data_out or OEB_i)
+always @ (posedge CE_i)
 	if (!OEB_i) 
 		O_i = data_out;
 	else


### PR DESCRIPTION
Original behavioral verilog only worked if OEB was tied low.

Attached image demonstrates behavior when OEB is set low only during read-address cycle. Note the incorrect O_i in the subsequent cycle.
![image](https://user-images.githubusercontent.com/14086183/103340542-2c320900-4a39-11eb-8845-e52315221890.png)
