### PR TITLE
Pass p_syn_in to hierarchical make rules.

### DIFF
--- a/src/hammer-vlsi/hammer_vlsi/hammer_build_systems.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_build_systems.py
@@ -298,7 +298,7 @@ def build_makefile(driver: HammerDriver, append_error_func: Callable[[str], None
             par_to_syn = ""
             if len(out_edges) > 0:
                 syn_deps = os.path.join(obj_dir, "syn-{}-input.json".format(node))
-                p_syn_in = "-p {}".format(syn_deps)
+                p_syn_in = "-p {}".format(syn_deps) + " " + p_syn_in
                 out_confs = [os.path.join(obj_dir, "par-" + x, "par-output-full.json") for x in out_edges]
                 prereqs = " ".join(out_confs)
                 pstring = " ".join(["-p " + x for x in out_confs])


### PR DESCRIPTION
Previously, hierarchical steps did not see a dependence on inputs.yml, sram-generator-output.json, and your INPUT_CONFS in the hierarchical flow.

A bug could occur if the hierarchical module contained its own SRAM macro that no leaf module included. Without appending to p_syn_in, sram-generator-output.json would not be included, and the tools would not be able to resolve the path to this macro.