### PR TITLE
Basic hierarchical support for sim & power

### DIFF
--- a/src/hammer-vlsi/hammer_vlsi/driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/driver.py
@@ -498,6 +498,8 @@ class HammerDriver:
         sim_tool.technology = self.tech
         sim_tool.input_files = self.database.get_setting("sim.inputs.input_files")
         sim_tool.top_module = self.database.get_setting("sim.inputs.top_module", nullvalue="")
+        sim_tool.hierarchical_mode = HierarchicalMode.from_str(
+            self.database.get_setting("vlsi.inputs.hierarchical.mode"))
         sim_tool.submit_command = HammerSubmitCommand.get("sim", self.database)
         sim_tool.all_regs = self.database.get_setting("sim.inputs.all_regs")
         sim_tool.seq_cells = self.database.get_setting("sim.inputs.seq_cells")
@@ -560,6 +562,8 @@ class HammerDriver:
         power_tool.logger = self.log.context("power")
         power_tool.technology = self.tech
         power_tool.set_database(self.database)
+        power_tool.hierarchical_mode = HierarchicalMode.from_str(
+            self.database.get_setting("vlsi.inputs.hierarchical.mode"))
         power_tool.submit_command = HammerSubmitCommand.get("power", self.database)
         power_tool.run_dir = run_dir
 

--- a/src/hammer-vlsi/hammer_vlsi/hammer_build_systems.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_build_systems.py
@@ -41,13 +41,13 @@ def build_makefile(driver: HammerDriver, append_error_func: Callable[[str], None
         - sim-par
         - power-par
 
-    For hierarchical flows, the syn, par, drc, and lvs actions will all be suffixed with the name
+    For hierarchical flows, the syn, par, drc, lvs, sim, and power actions will all be suffixed with the name
     of the hierarchical modules (e.g. syn-Top, syn-SubModA, par-SubModA, etc.). The appropriate
     dependencies and bridge actions are automatically generated from the hierarchy provided in the
     Hammer IR.
 
     For actions that can be run at multiple points in the flow such as sim, the name of the target
-    will include the action it is being run after (e.g. sim-syn, sim-par, etc.). With no suffix 
+    will include the action it is being run after (e.g. sim-syn, sim-par, etc.). With no suffix
     an rtl level simulation will be run.
 
     Additionally, "redo" steps are created (e.g. redo-par for flat designs or redo-par-Top for
@@ -170,7 +170,7 @@ def build_makefile(driver: HammerDriver, append_error_func: Callable[[str], None
 
         {power_par_in}: {par_out}
         \t$(HAMMER_EXEC) {env_confs} -p {par_out} $(HAMMER_EXTRA_ARGS) -o {power_par_in} --obj_dir {obj_dir} par-to-power
-        
+
         {power_par_out}: {power_sim_par_in} {power_par_in} $(HAMMER_POWER_PAR_DEPENDENCIES)
         \t$(HAMMER_EXEC) {env_confs} -p {power_sim_par_in} -p {power_par_in} $(HAMMER_EXTRA_ARGS) --power_rundir {power_par_run_dir} --obj_dir {obj_dir} power{suffix}
 


### PR DESCRIPTION
Pass hier stuff to sim & power actions. 

TODO: tool plugin implementation will require some additional documentation/keys (e.g. benchmarks are only valid for top-level hierarchy).