### PR TITLE
Hierarchical simulation netlists

### DIFF
--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -205,6 +205,7 @@ vlsi.inputs:
   # lef (str) - path to the LEF file
   # gds (str) - path to the GDS file
   # netlist (str) - path to the netlist file
+  # sim_netlist (str) - Optional. If specified, this netlist is appended for hierarchical simulation
   ilms: []
 
   # Multi-mode multi-corner setups, overrides supplies

--- a/src/hammer-vlsi/hammer_vlsi/constraints.py
+++ b/src/hammer-vlsi/hammer_vlsi/constraints.py
@@ -27,7 +27,8 @@ class ILMStruct(NamedTuple('ILMStruct', [
     ('module', str),
     ('lef', str),
     ('gds', str),
-    ('netlist', str)
+    ('netlist', str),
+    ('sim_netlist', Optional[str])
 ])):
     __slots__ = ()
 
@@ -38,7 +39,8 @@ class ILMStruct(NamedTuple('ILMStruct', [
             "module": self.module,
             "lef": self.lef,
             "gds": self.gds,
-            "netlist": self.netlist
+            "netlist": self.netlist,
+            "sim_netlist": self.sim_netlist
         }
 
     @staticmethod
@@ -49,7 +51,8 @@ class ILMStruct(NamedTuple('ILMStruct', [
             module=str(ilm["module"]),
             lef=str(ilm["lef"]),
             gds=str(ilm["gds"]),
-            netlist=str(ilm["netlist"])
+            netlist=str(ilm["netlist"]),
+            sim_netlist=ilm.get("sim_netlist")  # type: Optional[str]
         )
 
 

--- a/src/hammer-vlsi/hammer_vlsi/constraints.py
+++ b/src/hammer-vlsi/hammer_vlsi/constraints.py
@@ -52,7 +52,7 @@ class ILMStruct(NamedTuple('ILMStruct', [
             lef=str(ilm["lef"]),
             gds=str(ilm["gds"]),
             netlist=str(ilm["netlist"]),
-            sim_netlist=ilm.get("sim_netlist")  # type: Optional[str]
+            sim_netlist=ilm.get("sim_netlist")
         )
 
 

--- a/src/hammer-vlsi/hammer_vlsi/driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/driver.py
@@ -21,7 +21,7 @@ from .hammer_tool import HammerTool
 from .hooks import HammerToolHookAction
 from .hammer_vlsi_impl import HammerVLSISettings, HammerPlaceAndRouteTool, HammerSynthesisTool, \
     HammerSignoffTool, HammerDRCTool, HammerLVSTool, HammerSRAMGeneratorTool, HammerPCBDeliverableTool, HammerSimTool, HammerPowerTool, \
-    HierarchicalMode, load_tool, PlacementConstraint, SRAMParameters, ILMStruct
+    HierarchicalMode, load_tool, PlacementConstraint, SRAMParameters, ILMStruct, SimulationLevel
 from hammer_logging import HammerVLSIFileLogger, HammerVLSILogging, HammerVLSILoggingContext
 from .submit_command import HammerSubmitCommand
 
@@ -500,6 +500,11 @@ class HammerDriver:
         sim_tool.top_module = self.database.get_setting("sim.inputs.top_module", nullvalue="")
         sim_tool.hierarchical_mode = HierarchicalMode.from_str(
             self.database.get_setting("vlsi.inputs.hierarchical.mode"))
+        # Special case: if non-leaf hierarchical and gate-level, append ilm sim netlists
+        if sim_tool.hierarchical_mode.is_nonleaf_hierarchical() and sim_tool.level == SimulationLevel.GateLevel:
+            sim_netlists = list(map(lambda x: x.sim_netlist, sim_tool.get_input_ilms()))
+            sim_tool.input_files.extend(sim_netlists)
+        sim_tool.input_files = self.database.get_setting("sim.inputs.input_files")
         sim_tool.submit_command = HammerSubmitCommand.get("sim", self.database)
         sim_tool.all_regs = self.database.get_setting("sim.inputs.all_regs")
         sim_tool.seq_cells = self.database.get_setting("sim.inputs.seq_cells")

--- a/src/hammer-vlsi/hammer_vlsi/driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/driver.py
@@ -502,8 +502,9 @@ class HammerDriver:
             self.database.get_setting("vlsi.inputs.hierarchical.mode"))
         # Special case: if non-leaf hierarchical and gate-level, append ilm sim netlists
         if sim_tool.hierarchical_mode.is_nonleaf_hierarchical() and sim_tool.level == SimulationLevel.GateLevel:
-            sim_netlists = list(map(lambda x: x.sim_netlist, sim_tool.get_input_ilms()))
-            sim_tool.input_files.extend(sim_netlists)
+            for ilm in sim_tool.get_input_ilms():
+                if isinstance(ilm.sim_netlist, str):
+                    sim_tool.input_files.append(ilm.sim_netlist)
         sim_tool.input_files = self.database.get_setting("sim.inputs.input_files")
         sim_tool.submit_command = HammerSubmitCommand.get("sim", self.database)
         sim_tool.all_regs = self.database.get_setting("sim.inputs.all_regs")


### PR DESCRIPTION
This adds an optional `sim_netlist` field to the `ILMStruct`. If specified, this netlist is appended to a parent module's netlist for hierarchical simulation.

Used by ucb-bar/hammer-cadence-plugins/#64.