### PR TITLE
Early rail analysis

### DIFF
--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -676,6 +676,10 @@ par:
       # type: List[str]
       strap_layers: []
 
+  # Estimated power for early rail analysis
+  # This shall be estimated for the typical supply given in vlsi.inputs.supplies.VDD in units of Watts
+  rail_analysis_power: 1
+
 mentor:
     # Path to the folder with defaults.yml for common Mentor settings.
     common_path: "${vlsi.builtins.hammer_vlsi_path}/common/mentor"


### PR DESCRIPTION
Add `par.rail_analysis_power` key for ucb-bar/hammer-cadence-plugins#67. Defaults to 1 (unit of Watts).