### PR TITLE
Support relative directory meta application inside hierarchical constraints

### DIFF
--- a/src/hammer-vlsi/hammer_vlsi/driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/driver.py
@@ -1284,6 +1284,24 @@ class HammerDriver:
 
             hier_placement_constraints = {key: list(map(partial(PlacementConstraint.from_masters_and_dict, masters), lst))
                                           for key, lst in combined_raw_placement_dict.items()}
+            # Iterate over project configs to find which ones contain hierarchical constraints
+            # For each file that does append its path to the special key in the extracted
+            # hierarchical constraints section.
+            hier_constraint_source = ""  # type: str
+            for project_conf in self.project_configs:
+                if "vlsi.inputs.hierarchical.constraints" in project_conf:
+                    hier_constraint_source = project_conf[hammer_config._CONFIG_PATH_KEY]
+                    pc = project_conf["vlsi.inputs.hierarchical.constraints"]  # type: List[Dict]
+                    # Add CONFIG_PATH_KEY to actual project configs for each project config's hierarchical constraint
+                    # keys then update project configs at the end
+                    for md in pc:
+                        md  # one entry dict with a list
+                        for m in md.keys():
+                            if hammer_config._CONFIG_PATH_KEY in md[m][-1]:
+                                pass
+                            else:
+                                md[m].append({hammer_config._CONFIG_PATH_KEY: hier_constraint_source})
+            self.update_project_configs(self.project_configs)
             list_of_hier_constraints = self.database.get_setting(
                     "vlsi.inputs.hierarchical.constraints") # type: List[Dict]
             hier_constraints = reduce(add_dicts, list_of_hier_constraints, {})

--- a/src/hammer_config/__init__.py
+++ b/src/hammer_config/__init__.py
@@ -2,4 +2,5 @@
 
 # https://stackoverflow.com/questions/34461987/python3-importerror-no-module-named-xxxx
 from .config_src import *
+from .config_src import _CONFIG_PATH_KEY
 from .yaml2json import load_yaml


### PR DESCRIPTION
We add the special key for tracking relative directories to each dictionary that contains a `vlsi.inputs.hierarchical.constraints`.
This allows any future use of this dictionary to be able to resolve `prependlocal` meta actions or any future path relative meta actions.
We avoid adding this path variable if it already exists in the case that this procedure has already occured. Overwriting the path in that case would cause us to update it and then potentially disconnect the relative path from its original directory.
This happens in the normal usage with syn-to-par step creating a new hammer_config file in a different level of the directory hierarchy.