### PR TITLE
Flow Control Fixes + Enhancements

### DIFF
--- a/src/hammer-vlsi/hammer_vlsi/cli_driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/cli_driver.py
@@ -1053,11 +1053,22 @@ class CLIDriver:
         stop_step = only_step or to_step or until_step or None
         stop_incl = (only_step or to_step) is not None
         if (start_step or stop_step) is not None:
-            # TODO: do this for the rest of the actions
             driver.set_post_custom_syn_tool_hooks(HammerTool.make_start_stop_hooks(
                 HammerStartStopStep(step=start_step, inclusive=start_incl),
                 HammerStartStopStep(step=stop_step, inclusive=stop_incl)))
             driver.set_post_custom_par_tool_hooks(HammerTool.make_start_stop_hooks(
+                HammerStartStopStep(step=start_step, inclusive=start_incl),
+                HammerStartStopStep(step=stop_step, inclusive=stop_incl)))
+            driver.set_post_custom_drc_tool_hooks(HammerTool.make_start_stop_hooks(
+                HammerStartStopStep(step=start_step, inclusive=start_incl),
+                HammerStartStopStep(step=stop_step, inclusive=stop_incl)))
+            driver.set_post_custom_lvs_tool_hooks(HammerTool.make_start_stop_hooks(
+                HammerStartStopStep(step=start_step, inclusive=start_incl),
+                HammerStartStopStep(step=stop_step, inclusive=stop_incl)))
+            driver.set_post_custom_sim_tool_hooks(HammerTool.make_start_stop_hooks(
+                HammerStartStopStep(step=start_step, inclusive=start_incl),
+                HammerStartStopStep(step=stop_step, inclusive=stop_incl)))
+            driver.set_post_custom_power_tool_hooks(HammerTool.make_start_stop_hooks(
                 HammerStartStopStep(step=start_step, inclusive=start_incl),
                 HammerStartStopStep(step=stop_step, inclusive=stop_incl)))
 


### PR DESCRIPTION
Closes #554 and #585:
- Replaced steps use the new name in flow control
- Removed steps no longer targetable in flow control
- Get flow control hooks for drc, lvs, sim, power actions
- `first_step` and `persistent_steps` properties, `run_persistent_steps` method
- Persistent hooks and pre-persistent hooks whose target is the first step will always run at the beginning. See ucb-bar/hammer-cadence-plugins#71 for an example of how this is used in both `do_pre_steps` and the `open_chip` script.
- No change needed to unit tests