### PR TITLE
VCD -> waveforms, PG libraries are not files

### DIFF
--- a/doc/Hammer-Flow/Power.rst
+++ b/doc/Hammer-Flow/Power.rst
@@ -37,7 +37,7 @@ Simulation Input Keys
 
     * ``waveforms`` ([str])
 
-        * List of paths to VCD waveforms to be used for dynamic power analysis. Paths may be relative to the directory in which ``hammer-vlsi`` is called.
+        * List of paths to waveforms to be used for dynamic power analysis. Paths may be relative to the directory in which ``hammer-vlsi`` is called.
 
     * ``start_times`` ([TimeValue])
 

--- a/doc/Hammer-Flow/Simulation.rst
+++ b/doc/Hammer-Flow/Simulation.rst
@@ -115,7 +115,7 @@ The Hammer simulation tool will initialize register values in the simulation, as
 Simulation Outputs
 -------------------------------
 
-The simulation tool is able to output VCD/VPD files for the simulation. All of the relevant outputs of the simulation can be found in ``OBJ_DIR/sim-rundir/``.
+The simulation tool is able to output waveforms for the simulation. All of the relevant outputs of the simulation can be found in ``OBJ_DIR/sim-rundir/``.
 
 Simulation Commands
 -------------------------------

--- a/src/hammer-tech/filters.py
+++ b/src/hammer-tech/filters.py
@@ -311,5 +311,5 @@ class LibraryFilterHolder:
                         return 0  # put the technology library in front
             return 100  # put it behind
 
-        return LibraryFilter.new("power_grid_library", "Power grid library", is_file=True, filter_func=filter_func,
+        return LibraryFilter.new("power_grid_library", "Power grid library", is_file=False, filter_func=filter_func,
                                  paths_func=paths_func, sort_func=sort_func)

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -942,7 +942,8 @@ power.inputs:
   # type: List[str]
   spefs: []
 
-  # A list of paths to VCD waveforms to be used for dynamic power analysis.
+  # A list of paths to waveforms to be used for dynamic power analysis.
+  # Depending on the sim & power tool, these may be VCD/VPD, FSDB, SHM, etc. files/dirs.
   # type: List[str]
   waveforms: []
  

--- a/src/hammer-vlsi/hammer_vlsi/driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/driver.py
@@ -1062,7 +1062,7 @@ class HammerDriver:
     @staticmethod
     def sim_output_to_power_input(output_dict: dict) -> Optional[dict]:
         """
-        Generate the VCD inputs dynamic power analysis from the
+        Generate the inputs for dynamic power analysis from the
         outputs of simulations.
         Does not merge the results with any project dictionaries.
         :param output_dict: Dict containing sim.outputs.*


### PR DESCRIPTION
Minor fixes:

* Due to ucb-bar/hammer-cadence-plugins#72, mentions of "VCD" should instead be "waveforms" in documentation.

* Power grid libraries are directories, not files