### PR TITLE
Deepsubst multiple meta variables support

### DIFF
--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -430,14 +430,19 @@ def get_meta_directives() -> Dict[str, MetaDirective]:
                             if meta_key in oldval:
                                 # Do the deepsubst_meta, whatever it is.
                                 meta = oldval[meta_key]
-                                if meta in DeepSubstMetaDirectives:
-                                    if isinstance(v, str):
-                                        newval[k] = DeepSubstMetaDirectives[meta](v, params)
+                                if not isinstance(meta, list):
+                                    meta = [meta]
+                                intermediate_val = v
+                                for meta_var in meta:
+                                    if meta_var in DeepSubstMetaDirectives:
+                                        if isinstance(intermediate_val, str):
+                                            intermediate_val = DeepSubstMetaDirectives[meta_var](intermediate_val, params)
+                                        else:
+                                            raise ValueError("Deepsubst metas not supported on non-string values: {}".format(str(v)))
                                     else:
-                                        raise ValueError("Deepsubst metas not supported on non-string values: {}".format(str(v)))
-                                else:
-                                    raise ValueError("Unknown deepsubst_meta type: {}. Valid options are [{}].".format(str(meta),
-                                        ", ".join(DeepSubstMetaDirectives.keys())))
+                                        raise ValueError("Unknown deepsubst_meta type: {}. Valid options are [{}].".format(str(meta_var),
+                                            ", ".join(DeepSubstMetaDirectives.keys())))
+                                newval[k] = intermediate_val
                             else:
                                 newval[k] = do_subst(v)
                     else:


### PR DESCRIPTION
This should add in support for an arbitrary number of meta variables applied sequentially to the inner value. This has been shown to have no change with single meta variables, and to function with `"local"` and `"transclude"`. While `"cwd"` has not been tested, it looks like it _should_ work. This circumvents the issue where a list of meta deepsubst variables would cause Hammer to fail.