### PR TITLE
Update asap7 defaults.yml to conform with type checks

### DIFF
--- a/src/hammer-vlsi/technology/asap7/defaults.yml
+++ b/src/hammer-vlsi/technology/asap7/defaults.yml
@@ -15,7 +15,7 @@ vlsi:
   # Technology dimension
   # The PaR tool actually runs in the 4x scaled up lef/gds.
   # after PaR, post_par_script in asap7/__init__.py will scale down the generated gds to 7nm.
-  core.node: 28
+  core.node: "28"
   inputs:
     # Supply voltages.
     supplies:


### PR DESCRIPTION
Added quotation marks around the value of key core.node to comply with recenlty implemented type checks. Without this modification the following error arises TypeError: Expected primary type str for vlsi.core.node, got type int