### PR TITLE
Update defaults_types.yml to fix type error for vlsi.core.node

### DIFF
--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -8,7 +8,7 @@ vlsi.core:
   technology_path_meta: subst
 
   # Technology to use. hammer-vlsi will read this and load the appropriate technology libraries.
-  technology: "nop"
+  technology: 0
 
   # Technology node dimension (nm) to use.
   # Some tools change what they do as this changes.

--- a/src/hammer-vlsi/defaults_types.yml
+++ b/src/hammer-vlsi/defaults_types.yml
@@ -10,7 +10,7 @@ vlsi.core:
 
   # Technology node dimension (nm) to use.
   # Some tools change what they do as this changes.
-  node: str
+  node: int
 
   # Build system to use, if any.
   build_system: str


### PR DESCRIPTION
Changed default type of vlsi.core.node to int from str since in all the technology files `defaults.yml` the value is an int. Without this change the following error arises `Expected primary type str for vlsi.core.node, got type int`