### PR TITLE
Fix small error in tech defaults

### DIFF
--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -8,12 +8,12 @@ vlsi.core:
   technology_path_meta: subst
 
   # Technology to use. hammer-vlsi will read this and load the appropriate technology libraries.
-  technology: 0
+  technology: "nop"
 
   # Technology node dimension (nm) to use.
   # Some tools change what they do as this changes.
   # TODO: move this to vlsi.technology (or technology.core) ucb-bar/hammer#317
-  node: "nop"
+  node: 0
 
   # Build system to use, if any.
   # This is used to auto-generate a build file, if desired. It is not required to run hammer.


### PR DESCRIPTION
`vlsi.core.technology` is a str and `vlsi.core.node` is an int