### PR TITLE
Key history

### DIFF
--- a/doc/Hammer-Basics/Hammer-Setup.rst
+++ b/doc/Hammer-Basics/Hammer-Setup.rst
@@ -5,11 +5,9 @@ Hammer has a few requirements and there are several environment variables to set
 
 System Requirements
 -----------------------------
-- Python 3.6+ recommended (minimum Python 3.3+)
+- Python 3.6+ required
 
--- For Python 3.4 and lower, the ``typing`` module must be installed. (``python3 -m pip install typing``)
-
--- For Python 3.4, the enum34 package must be installed. (``python3 -m pip install enum34``)
+- The ``ruamel.yaml`` package is recommended for key history (``pip install ruamel.yaml``)
 
 - python3 in the $PATH
 

--- a/doc/Hammer-Use/Hammer-Config.rst
+++ b/doc/Hammer-Use/Hammer-Config.rst
@@ -226,6 +226,100 @@ The file should contain the same keys as the corresponding configuration file, b
 
 HAMMER will perform the same without a types file, but it is highly recommended to ensure type safety of any future plugins.
 
+Key History
+-----------
+
+When the ``ruamel.yaml`` package is installed, HAMMER can emit what files have modified any configuration keys in YAML format.
+The file is named ``{action}-output-history.yml`` and is located in the output folder of the given action.
+
+Example with the file ``test-config.yml``:
+
+  .. code-block:: yaml
+
+    synthesis.inputs:
+        input_files: ["foo", "bar"]
+        top_module: "z1top.xdc"
+
+    vlsi:
+        core:
+            technology: "nop"
+            technology_path: ["src/hammer-vlsi/technology"]
+
+            synthesis_tool: "nop"
+            synthesis_tool_path: ["src/hammer-vlsi/synthesis"]
+
+``test/syn-rundir/syn-output-history.yml`` after executing the command ``hammer-vlsi -p test-config.yml --obj_dir test syn``:
+
+  .. code-block:: yaml
+
+    synthesis.inputs.input_files:  # Modified by: test-config.yml
+      - LICENSE
+      - README.md
+    synthesis.inputs.top_module: z1top.xdc # Modified by: test-config.yml
+
+    vlsi.core.technology: nop # Modified by: test-config.yml
+    vlsi.core.technology_path: # Modified by: test-config.yml
+      - src/hammer-vlsi/technology
+    vlsi.core.synthesis_tool: nop # Modified by: test-config.yml
+    vlsi.core.synthesis_tool_path: # Modified by: test-config.yml
+      - src/hammer-vlsi/synthesis
+
+Example with the files ``test-config.yml`` and ``test-config2.yml``, respectively:
+
+  .. code-block:: yaml
+
+    synthesis.inputs:
+        input_files: ["foo", "bar"]
+        top_module: "z1top.xdc"
+
+    vlsi:
+        core:
+            technology: "nop"
+            technology_path: ["src/hammer-vlsi/technology"]
+
+            synthesis_tool: "nop"
+            synthesis_tool_path: ["src/hammer-vlsi/synthesis"]
+
+  .. code-block:: yaml
+
+    par.inputs:
+        input_files: ["foo", "bar"]
+        top_module: "z1top.xdc"
+
+    vlsi:
+        core:
+            technology: "${foo.subst}"
+            technology_path: ["/dev/null"]
+            technology_path_meta: subst
+
+            par_tool: "nop"
+            par_tool_path: ["src/hammer-vlsi/par"]
+
+    foo.subst: "nop2"
+
+``test/syn-rundir/par-output-history.yml`` after executing the command ``hammer-vlsi -p test-config.yml -p test-config2.yml --obj_dir test syn-par``:
+
+  .. code-block:: yaml
+
+    foo.subst: nop2 # Modified by: test-config2.yml
+    par.inputs.input_files:  # Modified by: test-config2.yml
+      - foo
+      - bar
+    par.inputs.top_module: z1top.xdc # Modified by: test-config2.yml
+    synthesis.inputs.input_files:  # Modified by: test-config.yml
+      - foo
+      - bar
+    synthesis.inputs.top_module: z1top.xdc # Modified by: test-config.yml
+    vlsi.core.technology: nop2 # Modified by: test-config.yml, test-config2.yml
+    vlsi.core.technology_path: # Modified by: test-config.yml, test-config2.yml
+      - /dev/null
+    vlsi.core.synthesis_tool: nop # Modified by: test-config.yml
+    vlsi.core.synthesis_tool_path: # Modified by: test-config.yml
+      - src/hammer-vlsi/synthesis
+    vlsi.core.par_tool: nop # Modified by: test-config2.yml
+    vlsi.core.par_tool_path: # Modified by: test-config2.yml
+      - src/hammer-vlsi/par
+
 Reference
 ---------
 

--- a/src/hammer-vlsi/cli_driver_test.py
+++ b/src/hammer-vlsi/cli_driver_test.py
@@ -542,6 +542,7 @@ class CLIDriverTest(unittest.TestCase):
         """Test that a key history file is created using synthesis."""
         # Check that ruamel.yaml is installed
         if importlib.util.find_spec("ruamel.yaml") is None:
+            warnings.warn("ruamel package not found, cannot test for key histories")
             return
 
         # Set up some temporary folders for the unit test.

--- a/src/hammer-vlsi/cli_driver_test.py
+++ b/src/hammer-vlsi/cli_driver_test.py
@@ -15,16 +15,19 @@ import warnings
 from decimal import Decimal
 from typing import Any, Callable, Dict, List, Optional
 
-if importlib.util.find_spec("ruamel.yaml") is None:
-    warnings.warn("ruamel package not found, cannot output key histories")
-else:
-    import ruamel.yaml
 import hammer_config
 from hammer_config import HammerJSONEncoder
 from hammer_logging.test import HammerLoggingCaptureContext
 from hammer_tech import MacroSize
 from hammer_vlsi import CLIDriver, HammerDriver, HammerDriverOptions, HammerVLSISettings, PlacementConstraint, PlacementConstraintType
 from hammer_utils import deepdict
+
+from hammer_vlsi.cli_driver import is_ruamel_missing
+
+if is_ruamel_missing():
+    warnings.warn("ruamel package not found, cannot output key histories")
+else:
+    import ruamel.yaml
 
 import unittest
 
@@ -541,7 +544,7 @@ class CLIDriverTest(unittest.TestCase):
     def test_key_history(self) -> None:
         """Test that a key history file is created using synthesis."""
         # Check that ruamel.yaml is installed
-        if importlib.util.find_spec("ruamel.yaml") is None:
+        if is_ruamel_missing():
             warnings.warn("ruamel package not found, cannot test for key histories")
             return
 
@@ -578,7 +581,7 @@ class CLIDriverTest(unittest.TestCase):
     def test_key_history_as_input(self) -> None:
         """Test that a key history file is created using synthesis."""
         # Check that ruamel.yaml is installed
-        if importlib.util.find_spec("ruamel.yaml") is None:
+        if is_ruamel_missing():
             warnings.warn("ruamel package not found, cannot test for key histories")
             return
 

--- a/src/hammer-vlsi/cli_driver_test.py
+++ b/src/hammer-vlsi/cli_driver_test.py
@@ -5,7 +5,7 @@
 #
 #  See LICENSE for licence details.
 
-import importlib
+import importlib.util
 import json
 import os
 import shutil

--- a/src/hammer-vlsi/cli_driver_test.py
+++ b/src/hammer-vlsi/cli_driver_test.py
@@ -27,7 +27,7 @@ from hammer_vlsi.cli_driver import is_ruamel_missing
 if is_ruamel_missing():
     warnings.warn("ruamel package not found, cannot output key histories")
 else:
-    import ruamel.yaml
+    import ruamel.yaml  # type: ignore
 
 import unittest
 

--- a/src/hammer-vlsi/cli_driver_test.py
+++ b/src/hammer-vlsi/cli_driver_test.py
@@ -5,14 +5,20 @@
 #
 #  See LICENSE for licence details.
 
+import importlib
 import json
 import os
 import shutil
 import tempfile
 import re
+import warnings
 from decimal import Decimal
 from typing import Any, Callable, Dict, List, Optional
 
+if importlib.util.find_spec("ruamel.yaml") is None:
+    warnings.warn("ruamel package not found, cannot output key histories")
+else:
+    import ruamel.yaml
 import hammer_config
 from hammer_config import HammerJSONEncoder
 from hammer_logging.test import HammerLoggingCaptureContext
@@ -532,6 +538,41 @@ class CLIDriverTest(unittest.TestCase):
                     return {bad: "bad"}
             BadOverride()
 
+    def test_key_history(self) -> None:
+        """Test that a key history file is created using synthesis."""
+        # Check that ruamel.yaml is installed
+        if importlib.util.find_spec("ruamel.yaml") is None:
+            return
+
+        # Set up some temporary folders for the unit test.
+        syn_rundir = tempfile.mkdtemp()
+        par_rundir = tempfile.mkdtemp()
+
+        # Generate a config for testing.
+        top_module = "dummy"
+        config_path = os.path.join(syn_rundir, "run_config.json")
+        syn_out_path = os.path.join(syn_rundir, "syn_out.json")
+        syn_to_par_out_path = os.path.join(syn_rundir, "syn_par_out.json")
+        history_path = os.path.join(syn_rundir, "syn-output-history.yml")
+        self.generate_dummy_config(syn_rundir, config_path, top_module)
+
+        self.run_syn_to_par_with_output(config_path, syn_rundir, par_rundir,
+                                        syn_out_path, syn_to_par_out_path)
+
+        # History file should have comments
+        with open(config_path, 'r') as f:
+            config = json.load(f)
+
+        with open(history_path, 'r') as f:
+            yaml = ruamel.yaml.YAML()
+            data = yaml.load(f)
+            for i in config.keys():
+                cmt = data.ca.items[i][2]
+                self.assertEqual(cmt.value, f"# Modified by: {config_path}\n")
+
+        # Cleanup
+        shutil.rmtree(syn_rundir)
+        shutil.rmtree(par_rundir)
 
 class HammerBuildSystemsTest(unittest.TestCase):
 

--- a/src/hammer-vlsi/hammer_vlsi/cli_driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/cli_driver.py
@@ -7,12 +7,17 @@
 #  See LICENSE for licence details.
 
 import argparse
+import importlib.util
 import json
 import os
 import subprocess
 import sys
+import warnings
 
-import ruamel.yaml
+if importlib.util.find_spec("ruamel.yaml") is None:
+    warnings.warn("ruamel package not found, cannot outout key histories")
+else:
+    import ruamel.yaml
 from .hammer_vlsi_impl import HammerTool, HammerVLSISettings
 from .hooks import HammerToolHookAction, HammerStartStopStep
 from .driver import HammerDriver, HammerDriverOptions
@@ -521,6 +526,7 @@ class CLIDriver:
             with open(key_history_f, 'r') as f:
                 key_history = json.load(f)
             os.remove(key_history_f)
+            spec = importlib.util.find_spec("ruamel.yaml")
             if action_type == "synthesis" or action_type == "syn":
                 if not driver.load_synthesis_tool(get_or_else(self.syn_rundir, "")):
                     return None
@@ -537,8 +543,9 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.syn_tool.run_dir, "syn-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.syn_tool.run_dir, "syn-output-full.json"),
                                          self.get_full_config(driver, output))
-                dump_config_to_yaml_file(os.path.join(driver.syn_tool.run_dir, "syn-output-history.yml"),
-                                         add_key_history(self.get_full_config(driver, output), key_history))
+                if spec is not None:
+                    dump_config_to_yaml_file(os.path.join(driver.syn_tool.run_dir, "syn-output-history.yml"),
+                                            add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
             elif action_type == "par":
                 if not driver.load_par_tool(get_or_else(self.par_rundir, "")):
@@ -556,8 +563,9 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.par_tool.run_dir, "par-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.par_tool.run_dir, "par-output-full.json"),
                                          self.get_full_config(driver, output))
-                dump_config_to_yaml_file(os.path.join(driver.par_tool.run_dir, "par-output-history.yml"),
-                                         add_key_history(self.get_full_config(driver, output), key_history))
+                if spec is not None:
+                    dump_config_to_yaml_file(os.path.join(driver.par_tool.run_dir, "par-output-history.yml"),
+                                            add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
             elif action_type == "drc":
                 if not driver.load_drc_tool(get_or_else(self.drc_rundir, "")):
@@ -575,8 +583,9 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.drc_tool.run_dir, "drc-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.drc_tool.run_dir, "drc-output-full.json"),
                                          self.get_full_config(driver, output))
-                dump_config_to_yaml_file(os.path.join(driver.drc_tool.run_dir, "drc-output-history.yml"),
-                                         add_key_history(self.get_full_config(driver, output), key_history))
+                if spec is not None:
+                    dump_config_to_yaml_file(os.path.join(driver.drc_tool.run_dir, "drc-output-history.yml"),
+                                            add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
             elif action_type == "lvs":
                 if not driver.load_lvs_tool(get_or_else(self.lvs_rundir, "")):
@@ -594,8 +603,9 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.lvs_tool.run_dir, "lvs-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.lvs_tool.run_dir, "lvs-output-full.json"),
                                          self.get_full_config(driver, output))
-                dump_config_to_yaml_file(os.path.join(driver.lvs_tool.run_dir, "lvs-output-history.yml"),
-                                         add_key_history(self.get_full_config(driver, output), key_history))
+                if spec is not None:
+                    dump_config_to_yaml_file(os.path.join(driver.lvs_tool.run_dir, "lvs-output-history.yml"),
+                                            add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
             elif action_type == "sram_generator":
                 if not driver.load_sram_generator_tool(get_or_else(self.sram_generator_rundir, "")):
@@ -627,8 +637,9 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.sim_tool.run_dir, "sim-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.sim_tool.run_dir, "sim-output-full.json"),
                                          self.get_full_config(driver, output))
-                dump_config_to_yaml_file(os.path.join(driver.sim_tool.run_dir, "sim-output-history.yml"),
-                                         add_key_history(self.get_full_config(driver, output), key_history))
+                if spec is not None:
+                    dump_config_to_yaml_file(os.path.join(driver.sim_tool.run_dir, "sim-output-history.yml"),
+                                            add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
             elif action_type == "power":
                 if not driver.load_power_tool(get_or_else(self.power_rundir, "")):
@@ -643,8 +654,9 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.power_tool.run_dir, "power-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.power_tool.run_dir, "power-output-full.json"),
                                          self.get_full_config(driver, output))
-                dump_config_to_yaml_file(os.path.join(driver.power_tool.run_dir, "power-output-history.yml"),
-                                         add_key_history(self.get_full_config(driver, output), key_history))
+                if spec is not None:
+                    dump_config_to_yaml_file(os.path.join(driver.power_tool.run_dir, "power-output-history.yml"),
+                                            add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
             elif action_type == "formal":
                 if not driver.load_formal_tool(get_or_else(self.formal_rundir, "")):
@@ -662,8 +674,9 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.formal_tool.run_dir, "formal-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.formal_tool.run_dir, "formal-output-full.json"),
                                          self.get_full_config(driver, output))
-                dump_config_to_yaml_file(os.path.join(driver.formal_tool.run_dir, "formal-output-history.yml"),
-                                         add_key_history(self.get_full_config(driver, output), key_history))
+                if spec is not None:
+                    dump_config_to_yaml_file(os.path.join(driver.formal_tool.run_dir, "formal-output-history.yml"),
+                                            add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
             elif action_type == "timing":
                 if not driver.load_timing_tool(get_or_else(self.timing_rundir, "")):
@@ -698,8 +711,9 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.pcb_tool.run_dir, "pcb-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.pcb_tool.run_dir, "pcb-output-full.json"),
                                          self.get_full_config(driver, output))
-                dump_config_to_yaml_file(os.path.join(driver.pcb_tool.run_dir, "pcb-output-history.yml"),
-                                         add_key_history(self.get_full_config(driver, output), key_history))
+                if spec is not None:
+                    dump_config_to_yaml_file(os.path.join(driver.pcb_tool.run_dir, "pcb-output-history.yml"),
+                                            add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
             else:
                 raise ValueError("Invalid action_type = " + str(action_type))

--- a/src/hammer-vlsi/hammer_vlsi/cli_driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/cli_driver.py
@@ -15,13 +15,13 @@ import sys
 import tempfile
 import warnings
 
-def is_ruamel_missing():
+def is_ruamel_missing() -> bool:
     return importlib.util.find_spec("ruamel") is None
 
 if is_ruamel_missing():
     warnings.warn("ruamel package not found, cannot output key histories")
 else:
-    import ruamel.yaml
+    import ruamel.yaml  # type: ignore
 from .hammer_vlsi_impl import HammerTool, HammerVLSISettings
 from .hooks import HammerToolHookAction, HammerStartStopStep
 from .driver import HammerDriver, HammerDriverOptions

--- a/src/hammer-vlsi/hammer_vlsi/cli_driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/cli_driver.py
@@ -1279,7 +1279,7 @@ class CLIDriver:
         # Intercept keys for determining key origin
         project_configs_yaml = load_config_from_paths(project_configs)
         project_configs_yaml_keys = [set(i.keys()) for i in project_configs_yaml]
-        key_history = {i: [] for i in reduce(lambda x, y: x.union(y), project_configs_yaml_keys)}
+        key_history: dict[str, list[str]] = {i: [] for i in reduce(lambda x, y: x.union(y), project_configs_yaml_keys)}
         for cfg_file, cfg in zip(project_configs, project_configs_yaml_keys):
             for key in cfg:
                 key_history[key].append(cfg_file)

--- a/src/hammer-vlsi/hammer_vlsi/cli_driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/cli_driver.py
@@ -33,7 +33,8 @@ from hammer_config import HammerJSONEncoder
 from hammer_config.config_src import load_config_from_paths
 
 
-KEY_PATH = os.path.join(tempfile.mkdtemp(), "key-history.json")
+KEY_DIR = tempfile.mkdtemp()
+KEY_PATH = os.path.join(KEY_DIR, "key-history.json")
 
 def parse_optional_file_list_from_args(args_list: Any, append_error_func: Callable[[str], None]) -> List[str]:
     """Parse a possibly null list of files, validate the existence of each file, and return a list of paths (possibly

--- a/src/hammer-vlsi/hammer_vlsi/cli_driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/cli_driver.py
@@ -517,6 +517,10 @@ class CLIDriver:
             # 3. Tech-supplied hooks
             # 4. User-supplied hooks
             assert driver.tech is not None, "must have a technology"
+            key_history_f = os.path.join(driver.obj_dir, KEY_HISTORY)
+            with open(key_history_f, 'r') as f:
+                key_history = json.load(f)
+            os.remove(key_history_f)
             if action_type == "synthesis" or action_type == "syn":
                 if not driver.load_synthesis_tool(get_or_else(self.syn_rundir, "")):
                     return None
@@ -533,10 +537,6 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.syn_tool.run_dir, "syn-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.syn_tool.run_dir, "syn-output-full.json"),
                                          self.get_full_config(driver, output))
-                key_history_f = os.path.join(driver.obj_dir, KEY_HISTORY)
-                with open(key_history_f, 'r') as f:
-                    key_history = json.load(f)
-                os.remove(key_history_f)
                 dump_config_to_yaml_file(os.path.join(driver.syn_tool.run_dir, "syn-output-history.yml"),
                                          add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
@@ -556,6 +556,8 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.par_tool.run_dir, "par-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.par_tool.run_dir, "par-output-full.json"),
                                          self.get_full_config(driver, output))
+                dump_config_to_yaml_file(os.path.join(driver.par_tool.run_dir, "par-output-history.yml"),
+                                         add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
             elif action_type == "drc":
                 if not driver.load_drc_tool(get_or_else(self.drc_rundir, "")):
@@ -573,6 +575,8 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.drc_tool.run_dir, "drc-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.drc_tool.run_dir, "drc-output-full.json"),
                                          self.get_full_config(driver, output))
+                dump_config_to_yaml_file(os.path.join(driver.drc_tool.run_dir, "drc-output-history.yml"),
+                                         add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
             elif action_type == "lvs":
                 if not driver.load_lvs_tool(get_or_else(self.lvs_rundir, "")):
@@ -590,6 +594,8 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.lvs_tool.run_dir, "lvs-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.lvs_tool.run_dir, "lvs-output-full.json"),
                                          self.get_full_config(driver, output))
+                dump_config_to_yaml_file(os.path.join(driver.lvs_tool.run_dir, "lvs-output-history.yml"),
+                                         add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
             elif action_type == "sram_generator":
                 if not driver.load_sram_generator_tool(get_or_else(self.sram_generator_rundir, "")):
@@ -621,6 +627,8 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.sim_tool.run_dir, "sim-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.sim_tool.run_dir, "sim-output-full.json"),
                                          self.get_full_config(driver, output))
+                dump_config_to_yaml_file(os.path.join(driver.sim_tool.run_dir, "sim-output-history.yml"),
+                                         add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
             elif action_type == "power":
                 if not driver.load_power_tool(get_or_else(self.power_rundir, "")):
@@ -635,6 +643,8 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.power_tool.run_dir, "power-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.power_tool.run_dir, "power-output-full.json"),
                                          self.get_full_config(driver, output))
+                dump_config_to_yaml_file(os.path.join(driver.power_tool.run_dir, "power-output-history.yml"),
+                                         add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
             elif action_type == "formal":
                 if not driver.load_formal_tool(get_or_else(self.formal_rundir, "")):
@@ -652,6 +662,8 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.formal_tool.run_dir, "formal-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.formal_tool.run_dir, "formal-output-full.json"),
                                          self.get_full_config(driver, output))
+                dump_config_to_yaml_file(os.path.join(driver.formal_tool.run_dir, "formal-output-history.yml"),
+                                         add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
             elif action_type == "timing":
                 if not driver.load_timing_tool(get_or_else(self.timing_rundir, "")):
@@ -686,6 +698,8 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.pcb_tool.run_dir, "pcb-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.pcb_tool.run_dir, "pcb-output-full.json"),
                                          self.get_full_config(driver, output))
+                dump_config_to_yaml_file(os.path.join(driver.pcb_tool.run_dir, "pcb-output-history.yml"),
+                                         add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
             else:
                 raise ValueError("Invalid action_type = " + str(action_type))

--- a/src/hammer-vlsi/hammer_vlsi/cli_driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/cli_driver.py
@@ -15,7 +15,10 @@ import sys
 import tempfile
 import warnings
 
-if importlib.util.find_spec("ruamel.yaml") is None:
+def is_ruamel_missing():
+    return importlib.util.find_spec("ruamel") is None
+
+if is_ruamel_missing():
     warnings.warn("ruamel package not found, cannot output key histories")
 else:
     import ruamel.yaml
@@ -72,7 +75,7 @@ def dump_config_to_json_file(output_path: str, config: dict) -> None:
     with open(output_path, "w") as f:
         f.write(json.dumps(config, cls=HammerJSONEncoder, indent=4))
 
-def dump_config_to_yaml_file(output_path: str, config: ruamel.yaml.CommentedMap) -> None:
+def dump_config_to_yaml_file(output_path: str, config: Any) -> None:
     """
     Helper function to dump the given config in YAML form
     to the given output path while overwriting it if it already exists.
@@ -84,7 +87,7 @@ def dump_config_to_yaml_file(output_path: str, config: ruamel.yaml.CommentedMap)
     with open(output_path, 'w') as f:
         yaml.dump(config, f)
 
-def add_key_history(config: dict, history: dict) -> ruamel.yaml.CommentedMap:
+def add_key_history(config: dict, history: dict) -> Any:
     """
     Generates a YAML file with comments indicating what files modified said keys.
     """
@@ -527,7 +530,6 @@ class CLIDriver:
             assert driver.tech is not None, "must have a technology"
             with open(KEY_PATH, 'r') as f:
                 key_history = json.load(f)
-            spec = importlib.util.find_spec("ruamel.yaml")
             if action_type == "synthesis" or action_type == "syn":
                 if not driver.load_synthesis_tool(get_or_else(self.syn_rundir, "")):
                     return None
@@ -544,7 +546,7 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.syn_tool.run_dir, "syn-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.syn_tool.run_dir, "syn-output-full.json"),
                                          self.get_full_config(driver, output))
-                if spec is not None:
+                if not is_ruamel_missing():
                     dump_config_to_yaml_file(os.path.join(driver.syn_tool.run_dir, "syn-output-history.yml"),
                                             add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
@@ -564,7 +566,7 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.par_tool.run_dir, "par-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.par_tool.run_dir, "par-output-full.json"),
                                          self.get_full_config(driver, output))
-                if spec is not None:
+                if not is_ruamel_missing():
                     dump_config_to_yaml_file(os.path.join(driver.par_tool.run_dir, "par-output-history.yml"),
                                             add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
@@ -584,7 +586,7 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.drc_tool.run_dir, "drc-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.drc_tool.run_dir, "drc-output-full.json"),
                                          self.get_full_config(driver, output))
-                if spec is not None:
+                if not is_ruamel_missing():
                     dump_config_to_yaml_file(os.path.join(driver.drc_tool.run_dir, "drc-output-history.yml"),
                                             add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
@@ -604,7 +606,7 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.lvs_tool.run_dir, "lvs-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.lvs_tool.run_dir, "lvs-output-full.json"),
                                          self.get_full_config(driver, output))
-                if spec is not None:
+                if not is_ruamel_missing():
                     dump_config_to_yaml_file(os.path.join(driver.lvs_tool.run_dir, "lvs-output-history.yml"),
                                             add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
@@ -638,7 +640,7 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.sim_tool.run_dir, "sim-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.sim_tool.run_dir, "sim-output-full.json"),
                                          self.get_full_config(driver, output))
-                if spec is not None:
+                if not is_ruamel_missing():
                     dump_config_to_yaml_file(os.path.join(driver.sim_tool.run_dir, "sim-output-history.yml"),
                                             add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
@@ -655,7 +657,7 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.power_tool.run_dir, "power-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.power_tool.run_dir, "power-output-full.json"),
                                          self.get_full_config(driver, output))
-                if spec is not None:
+                if not is_ruamel_missing():
                     dump_config_to_yaml_file(os.path.join(driver.power_tool.run_dir, "power-output-history.yml"),
                                             add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
@@ -675,7 +677,7 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.formal_tool.run_dir, "formal-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.formal_tool.run_dir, "formal-output-full.json"),
                                          self.get_full_config(driver, output))
-                if spec is not None:
+                if not is_ruamel_missing():
                     dump_config_to_yaml_file(os.path.join(driver.formal_tool.run_dir, "formal-output-history.yml"),
                                             add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)
@@ -712,7 +714,7 @@ class CLIDriver:
                 dump_config_to_json_file(os.path.join(driver.pcb_tool.run_dir, "pcb-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.pcb_tool.run_dir, "pcb-output-full.json"),
                                          self.get_full_config(driver, output))
-                if spec is not None:
+                if not is_ruamel_missing():
                     dump_config_to_yaml_file(os.path.join(driver.pcb_tool.run_dir, "pcb-output-history.yml"),
                                             add_key_history(self.get_full_config(driver, output), key_history))
                 post_run_func_checked(driver)

--- a/src/hammer-vlsi/hammer_vlsi/cli_driver.py
+++ b/src/hammer-vlsi/hammer_vlsi/cli_driver.py
@@ -1279,7 +1279,7 @@ class CLIDriver:
         # Intercept keys for determining key origin
         project_configs_yaml = load_config_from_paths(project_configs)
         project_configs_yaml_keys = [set(i.keys()) for i in project_configs_yaml]
-        key_history: dict[str, list[str]] = {i: [] for i in reduce(lambda x, y: x.union(y), project_configs_yaml_keys)}
+        key_history: Dict[str, List[str]] = {i: [] for i in reduce(lambda x, y: x.union(y), project_configs_yaml_keys)}
         for cfg_file, cfg in zip(project_configs, project_configs_yaml_keys):
             for key in cfg:
                 key_history[key].append(cfg_file)

--- a/src/hammer-vlsi/synthesis/yosys/__init__.py
+++ b/src/hammer-vlsi/synthesis/yosys/__init__.py
@@ -208,6 +208,7 @@ class YosysSynth(HammerSynthesisTool, OpenROADTool, TCLTool):
         self.synth_cap_load = 33.5 # SYNTH_CAP_LOAD
         self.max_fanout = 5 # default SYNTH_MAX_FANOUT = 5
 
+        
         self.driver_cell = None
         driver_cells = self.technology.get_special_cell_by_type(CellType.Driver)
         if driver_cells is None or driver_cells[0].input_ports is None or driver_cells[0].output_ports is None:
@@ -216,10 +217,15 @@ class YosysSynth(HammerSynthesisTool, OpenROADTool, TCLTool):
             self.driver_cell = driver_cells[0].name[0]
             self.driver_ports_in = driver_cells[0].input_ports[0]
             self.driver_ports_out = driver_cells[0].output_ports[0]
+
         # Yosys commands only take a single lib file
         #   so use typical corner liberty file
         corners = self.get_mmmc_corners()  # type: List[MMMCCorner]
-        corner_tt = next((corner for corner in corners if corner.type == MMMCCornerType.Extra), None)
+        try:
+            corner_tt = next((corner for corner in corners if corner.type == MMMCCornerType.Extra), None)
+        except:
+            raise ValueError("An extra corner is required for Yosys.")
+            
         self.liberty_file = self.get_timing_libs(corner_tt)
         
         self.append("yosys -import")

--- a/src/hammer-vlsi/tech_test.py
+++ b/src/hammer-vlsi/tech_test.py
@@ -675,9 +675,11 @@ END LIBRARY
             out_dict.update({"special_cells": [
                                 {"name": ["cell1"], "cell_type": "tiehicell"},
                                 {"name": ["cell2"], "cell_type": "tiehicell", "size": ["1.5"]},
-                                {"name": ["cell3"], "cell_type": "iofiller", "size": ["0.5"]},
-                                {"name": ["cell4"], "cell_type": "stdfiller"},
+                                {"name": ["cell3"], "cell_type": "iofiller", "size": ["0.5"], "input_ports": ["A","B"], "output_ports": ["Y"]},
+                                {"name": ["cell4"], "cell_type": "stdfiller", "input_ports": ["A"], "output_ports": ["Y", "Z"]}, 
                                 {"name": ["cell5"], "cell_type": "endcap"},
+                                {"name": ["cell6"], "cell_type": "tielocell"},
+                                {"name": ["cell7"], "cell_type": "tiehicell"},
                              ]})
             return out_dict
         HammerToolTestHelpers.write_tech_json(tech_json_filename, add_special_cells)
@@ -690,9 +692,11 @@ END LIBRARY
         database = hammer_config.HammerDatabase()
         tool.set_database(database)
 
+
         self.assertEqual(tool.technology.get_special_cell_by_type(CellType.TieHiCell),
                 [SpecialCell(name=list(["cell1"]), cell_type=CellType.TieHiCell, size=None, input_ports=None, output_ports=None),
-                 SpecialCell(name=list(["cell2"]), cell_type=CellType.TieHiCell, size=list(["1.5"]), input_ports=None, output_ports=None)
+                 SpecialCell(name=list(["cell2"]), cell_type=CellType.TieHiCell, size=list(["1.5"]), input_ports=None, output_ports=None),
+                 SpecialCell(name=list(["cell7"]), cell_type=CellType.TieHiCell, size=None, input_ports=None, output_ports=None )
                 ])
 
         self.assertEqual(tool.technology.get_special_cell_by_type(CellType.IOFiller),
@@ -711,9 +715,9 @@ END LIBRARY
                 [SpecialCell(name=list(["cell6"]), cell_type=CellType.TieLoCell, size=None, input_ports=None, output_ports=None )
                 ])
 
-        self.assertEqual(tool.technology.get_special_cell_by_type(CellType.TieHiCell),
-                [SpecialCell(name=list(["cell7"]), cell_type=CellType.TieHiCell, size=None, input_ports=None, output_ports=None )
-                ])
+        # self.assertEqual(tool.technology.get_special_cell_by_type(CellType.TieHiCell),
+        #         [SpecialCell(name=list(["cell7"]), cell_type=CellType.TieHiCell, size=None, input_ports=None, output_ports=None )
+        #         ])
 
     def test_drc_lvs_decks(self) -> None:
         """

--- a/src/hammer_config/config_src.py
+++ b/src/hammer_config/config_src.py
@@ -764,9 +764,14 @@ class HammerDatabase:
         :param check_type: Flag to enforce type checking
         :return: The given config
         """
+        CFG_PATH = os.path.join(os.path.dirname(os.getcwd()), "hammer-vlsi")
+        defaults = unpack(load_config_from_defaults(CFG_PATH)[1])
+
         IGNORE = ["vlsi.builtins.hammer_vlsi_path", "vlsi.builtins.is_complete"]
         if key not in self.get_config():
             raise KeyError("Key " + key + " is missing")
+        if key not in IGNORE and key not in defaults:
+            warn(f"Key {key} does not have a default implementation")
         if check_type and key not in IGNORE:
             if key not in self.get_config_types():
                 warn(f"Key {key} is not associated with a type")


### PR DESCRIPTION
Every run of the CLI now creates a `{action}-output-history.yml` file that contains a flattened version of the full output config, annotated with comments describing the files that modified said keys in the order they were provided as project files in the CLI call. This is done by creating a temporary file similar in fashion to the CLI driver tests.

The feature requires the package [`ruamel.yaml`](https://pypi.org/project/ruamel.yaml/) since the `pyyaml` package does not support reading and writing comments in YAML.