### PR TITLE
Add Overlap placement constraint type

### DIFF
--- a/src/hammer-vlsi/constraints_test.py
+++ b/src/hammer-vlsi/constraints_test.py
@@ -731,5 +731,35 @@ class PlacementConstraintTest(unittest.TestCase):
         self.assertEqual(tc.orientation, "mx")
         self.assertEqual(tc.master, "bar")
 
+    def test_master_overlap(self) -> None:
+        d = {"type": "overlap",
+             "path": "path/to/placement",
+             "x": Decimal(4),
+             "y": Decimal(6),
+             "width": Decimal(10),
+             "height": Decimal(20),
+             "orientation": "mx",
+             "create_physical": True,
+             "master": "overlap_cell"}
+        tc = PlacementConstraint.from_dict(d)
+        self.assertEqual(tc.type, PlacementConstraintType.Overlap)
+        self.assertEqual(tc.path, "path/to/placement")
+        self.assertEqual(tc.x, Decimal(4))
+        self.assertEqual(tc.y, Decimal(6))
+        self.assertEqual(tc.width, Decimal(10))
+        self.assertEqual(tc.height, Decimal(20))
+        self.assertEqual(tc.orientation, "mx")
+        self.assertEqual(tc.create_physical, True)
+        self.assertEqual(tc.master, "overlap_cell")
+        with self.assertRaises(ValueError):
+            m = {"margins": Margins.empty().to_dict()}
+            # This should assert because margins are not allowed
+            tc = PlacementConstraint.from_dict(add_dicts(d, m))
+        with self.assertRaises(ValueError):
+            tl = {"top_layer": "m4"}
+            # This should assert because top layer is not allowed
+            tc = PlacementConstraint.from_dict(add_dicts(d, tl))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/hammer-vlsi/defaults.yml
+++ b/src/hammer-vlsi/defaults.yml
@@ -244,6 +244,7 @@ vlsi.inputs:
   #   - "hardmacro" (places this hard macro at a particular spot)
   #   - "hierarchical" (marks this instance as part of hierarchical place and route)
   #   - "obstruction" (creates a blockage at a particular spot; see obs_types)
+  #   - "overlap" (places this overlapping macro at a particular spot but does not add any halos/obstructions)
   # orientation (Optional[str]) - The orientation
   # - Optional for all types
   # - Valid options:
@@ -260,15 +261,15 @@ vlsi.inputs:
   # y (float) - y coordinate in um
   # - Required for all types
   # width (float) - width in um
-  # - Required for all types, but can be auto-filled for hierarchical and hardmacro if left blank
+  # - Required for all types, but can be auto-filled for hierarchical, hardmacro, and overlap if left blank
   # height (float) - height in um
-  # - Required for all types, but can be auto-filled for hierarchical and hardmacro if left blank
-  # master (Optional[str]) - The master module name of the hierarchical or hardmacro constraint.
+  # - Required for all types, but can be auto-filled for hierarchical, hardmacro, and overlap if left blank
+  # master (Optional[str]) - The master module name of the hierarchical, hardmacro, or overlap constraint.
   #                          For example, if this hardmacro is an instance of "my_amplifier", this
   #                          field should be set to "my_amplifier".
-  # - Required for hierarchical and optional for hardmacro, disallowed otherwise
+  # - Required for hierarchical and optional for hardmacro and overlap, disallowed otherwise
   # create_physical (Optional[bool]) - Create an instance of a physical-only cell that does not exist in addition to placing it
-  # - Optional for hardmacro, disallowed otherwise
+  # - Optional for hardmacro and overlap, disallowed otherwise
   # margins (Optional[Margins]) - margins for the top-level module.
   # - Required for toplevel, disallowed otherwise
   # - Contains the following keys:
@@ -277,7 +278,7 @@ vlsi.inputs:
   #   - "top"    (margin from the top side of the core PNR area to the edge of the chip)
   #   - "bottom" (margin from the bottom side of the core PNR area to the edge of the chip)
   # top_layer (str) - Specifies the highest layer used by this hierarchical or hardmacro, used to keep other wires away
-  # - Optional for hierarchical and hardmacro
+  # - Optional for hierarchical and hardmacro, disallowed otherwise
   # layers (List[str]) - A list of strings that enumerates layer(s) blocked by the obstruction otherwise all layers are blocked
   # - Required for the obstruction type, disallowed otherwise
   # obs_types (List[str]) - A list of the types of obstructions for the given geometry

--- a/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
+++ b/src/hammer-vlsi/hammer_vlsi/hammer_tool.py
@@ -1252,6 +1252,8 @@ class HammerTool(metaclass=ABCMeta):
                     # already enforced to have width & height
                     obs_rects += '<rect x="{}" y="{}" width="{}" height="{}" class="obs" />\n'.format(c.x, top.height-c.y-c.height, c.width, c.height)
                     obs_text += '<text text-anchor="middle" x="{}" y="{}" class="bold10pt">{}</text>\n'.format(c.x+c.width/2, top.height-c.y-c.height/2, shorten(c.path))
+                elif c.type == PlacementConstraintType.Overlap:
+                    self.logger.info('Overlap constraint {} skipped from visualization.'.format(c.path))
 
             # Draw order: obstructions, macros, orientation lines
             fsvg.write("</g>\n".join([obs_rects, obs_text, macro_rects, macro_text, orient_lines]) + "</g>\n")


### PR DESCRIPTION
Overlap should be used for certain type of cells. In LEFs, these should be of class COVER or of class MACRO with OVERLAP shapes inside.

This is particularly useful to prevent any P&R implementations from creating halo/blockage objects around the boundaries of these macros.