### PR TITLE
Utility Function v2

### DIFF
--- a/hammer/config/config_src.py
+++ b/hammer/config/config_src.py
@@ -854,6 +854,31 @@ class HammerDatabase:
                     raise TypeError(f"Expected tertiary value type {exp_value_type.tertiary_v.value} for {key}, got type {v_type}")
         return True
 
+    def get_settings_from_dict(self, key_default_dict: Dict[str, Any], key_prefix: str = "", optional_keys: List[str] = []) -> Dict[str, str]:
+        """
+        Gets input values for multiple keys.
+        :param key_default_dict: Specify a dictionary of requested keys and default values.
+        :param key_prefix: Specify a prefix for the given keys.
+        :optional_keys: Specify optional keys where if no setting is provided a default value of None will be provided.
+        :return: A dictionary of keys and corresponding input values.
+        """
+
+        opt_dict={}
+        for key, default_value in key_default_dict.items():
+            try: 
+                if not key_prefix:
+                    extracted_value = self.get_setting(f"{key}", default_value)
+                else:
+                    extracted_value = self.get_setting(f"{key_prefix}.{key}", default_value)
+                opt_dict[key] = extracted_value
+            except KeyError:
+                if key not in optional_keys:
+                    raise ValueError(f"Missing a mandatory requested key: {key_prefix}.{key}")
+                else: 
+                    opt_dict[key] = None
+
+        return opt_dict
+
     def update_core(self, core_config: List[dict], core_config_types: List[dict]) -> None:
         """
         Update the core config with the given core config.

--- a/hammer/vlsi/hammer_tool.py
+++ b/hammer/vlsi/hammer_tool.py
@@ -905,6 +905,12 @@ class HammerTool(metaclass=ABCMeta):
         """
         self._database.set_setting(key, value)
 
+    def get_settings_from_dict(self, key_default_dict: Dict[str, Any], key_prefix: str = "", optional_keys: List[str] = []) -> Dict[str, str]:
+        """
+        Gets input values for multiple keys.
+        """
+        return self._database.get_settings_from_dict(key_default_dict, key_prefix, optional_keys)
+
     def create_enter_script(self, enter_script_location: str = "", raw: bool = False) -> None:
         """
         Create the enter script inside the rundir which can be used to


### PR DESCRIPTION
A quick PR to merge a simple utility method `get_settings_from_dict` originating from Xcelium PR. Goal is to simplify/standardize the process of getting multiple keys (often specified as a list of keys on which to perform `get_setting`) at once and returning a unified dictionary. Currently, such functionality is handled in multiple slightly different ways across the plugins.

Accompanied now by a unit test.