### PR TITLE
Workflow to Publish Hammer on Release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: hammer-publish-ci
+
+# https://nadeauinnovations.com/post/2020/08/one-version-to-rule-them-all-keeping-your-python-package-version-number-in-sync-with-git-and-poetry/
+
+on:
+  release:
+    types: [created]
+
+env:
+  POETRY_VERSION: "1.3.2"
+  PYTHON_VERSION: "3.9"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          version: ${{ env.POETRY_VERSION }}
+      - name: Create Poetry env
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry install --no-ansi
+      - name: Publish
+        id: publish
+        run: |
+          poetry version $(git describe --tags --abbrev=0)
+          poetry build
+          poetry publish --username "__token__" --password ${{ secrets.PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hammer-vlsi"
-version = "0.0.1"
+version = "0.0.0"
 description = "Hammer is a physical design framework that wraps around vendor specific technologies and tools to provide a single API to create ASICs."
 authors = ["Colin Schmidt <colin.schmidt@sifive.com>", "Edward Wang <edward.c.wang@compdigitec.com>", "John Wright <johnwright@eecs.berkeley.edu>"]
 maintainers = ["Harrison Liew <harrisonliew@berkeley.edu>", "Daniel Grubb <dpgrubb@berkeley.edu>"]


### PR DESCRIPTION
This workflow will publish hammer to PyPI when a release is created on Github. The version number used in the tag of the release will be used as the version for the hammer-vlsi package. The PYPI_TOKEN used is mine, but once the package is published, I will add everyone else as admins on PyPI for hammer-vlsi.

Workflow based on this: https://nadeauinnovations.com/post/2020/08/one-version-to-rule-them-all-keeping-your-python-package-version-number-in-sync-with-git-and-poetry/