### PR TITLE
Cache Poetry venv in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,7 +38,14 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           version: ${{ env.POETRY_VERSION }}
+      - name: Load Cached Poetry virtualenv
+        id: cached-venv
+        uses: actions/cache@v3
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Create Poetry env
+        if: steps.cached-venv.outputs.cache-hit != 'true'
         run: |
           poetry config virtualenvs.in-project true
           poetry install --no-ansi


### PR DESCRIPTION
Caches the venv generated by poetry install as long as the OS, python version, and poetry.lock files stay the same. Should reduce CI runtime to under 1 minute.

Based on: https://github.com/snok/install-poetry#testing