### PR TITLE
Bump Update

### DIFF
--- a/hammer/config/config_src.py
+++ b/hammer/config/config_src.py
@@ -729,6 +729,11 @@ class HammerDatabase:
         """Alias for get_setting()."""
         return self.get_setting(key)
 
+    def get_suffix(self, key: str, suffix: str) -> Any:
+        """Alias for get_setting_suffix()."""
+        return self.get_setting_suffix(key, suffix)
+
+
     def __getitem__(self, key: str) -> Any:
         """Alias for get_setting()."""
         return self.get_setting(key)
@@ -753,6 +758,33 @@ class HammerDatabase:
         if check_type:
             self.check_setting(key)
         value = self.get_config()[key]
+        return nullvalue if value is None else value
+
+    def get_setting_suffix(self, key: str, suffix: str, nullvalue: Any = None, check_type: bool = True) -> Any:
+        """
+        Retrieve a key, first trying with a suffix but returning base if found.
+
+        :param key: Desired key.
+        :param suffix: Required suffix to search for.
+        :param nullvalue: Value to return out for nulls.
+        :param check_type: Flag to enforce type checking
+        :return: The given config
+        """
+        default  = key
+        override = default + "_" + suffix
+        value = None
+        try: 
+            value = self.get_config()[override]
+        except:
+            try:
+                value = self.get_config()[default]
+            except:
+                raise KeyError(f"Both base key: {default} and overriden key: {override} are missing.")
+
+        if default not in self.defaults:
+            warn(f"Base key: {default} does not have a default implementation")
+        if check_type:
+            self.check_setting(default)
         return nullvalue if value is None else value
 
     def set_setting(self, key: str, value: Any) -> None:

--- a/hammer/config/defaults.yml
+++ b/hammer/config/defaults.yml
@@ -301,7 +301,12 @@ vlsi.inputs:
   # BumpsDefinition struct members
     x: 0 # x (int) - number of bumps in the x dimension
     y: 0 # y (int) - number of bumps in the y dimension
-    pitch: 0.0 # pitch (float) - pitch of bumps in microns
+    # pitch (float) - pitch of bumps in microns
+    # Overrideable by appending _<dim name>
+    # type: float
+    pitch: 0.0
+    global_x_offset: 0.0 # offset the bump map in the x-axis (float)
+    global_y_offset: 0.0 # offset the bump map in the y-axis (float)    
     cell: "" # cell (str) - Name of the default bump cell
     assignments: [] # assignments - List of BumpAssignment structs. You must specify one of name or no_connect.
     # If both are specified the bump will be left unconnected

--- a/hammer/config/defaults_types.yml
+++ b/hammer/config/defaults_types.yml
@@ -143,6 +143,10 @@ vlsi.inputs:
     y: int
     # pitch (float) - pitch of bumps in microns
     pitch: float
+    # global_x_offset (float) - offset the bump map in the x-axis 
+    global_x_offset: float
+    # global_y_offset (float) - offset the bump map in the y-axis 
+    global_y_offset: float
     # cell (str) - Name of the default bump cell
     cell: str
     # assignments - List of BumpAssignment structs. You must specify one of name or no_connect.

--- a/hammer/pcb/generic/__init__.py
+++ b/hammer/pcb/generic/__init__.py
@@ -111,18 +111,19 @@ class GenericPCBDeliverableTool(HammerPCBDeliverableTool):
         sorted_assignments = naming_scheme.sort_by_name(bumps, assignments)
 
         # Use post-shrink pitch
-        pitch = self.technology.get_post_shrink_length(bumps.pitch)
+        pitch_x = self.technology.get_post_shrink_length(bumps.pitch_x)
+        pitch_y = self.technology.get_post_shrink_length(bumps.pitch_y)
 
         # There is no meaningful verion for this file
         # Set the units to metric (mm)
         output = "VER 0.0\nUNIT M\n"
-        x_offset = ((1 - bumps.x) * pitch) / 2  # type: Decimal
-        y_offset = ((1 - bumps.y) * pitch) / 2  # type: Decimal
+        x_offset = ((1 - bumps.x) * pitch_x) / 2  # type: Decimal
+        y_offset = ((1 - bumps.y) * pitch_y) / 2  # type: Decimal
         for bump in sorted_assignments:
             # note that the flip-chip mirroring happens here
             name = naming_scheme.name_bump(bumps, bump)
-            x = um2mm(Decimal(str(bumps.x - bump.x)) * pitch + x_offset, 3)
-            y = um2mm(Decimal(str(bump.y - 1)) * pitch + y_offset, 3)
+            x = um2mm(Decimal(str(bumps.x - bump.x)) * pitch_x + x_offset, 3)
+            y = um2mm(Decimal(str(bump.y - 1)) * pitch_y + y_offset, 3)
             # Fields in order (with valid options):
             # Name
             # X position (mm)
@@ -182,14 +183,15 @@ class GenericPCBDeliverableTool(HammerPCBDeliverableTool):
         bumps, assignments = self.get_bumps_and_assignments()
 
         # Use post-shrink pitch
-        pitch = self.technology.get_post_shrink_length(bumps.pitch)
+        pitch_x = self.technology.get_post_shrink_length(bumps.pitch_x)
+        pitch_y = self.technology.get_post_shrink_length(bumps.pitch_y)
 
         # Here is a good ref for the PADS V9 format:
         # ftp://ftp.freecalypso.org/pub/CAD/PADS/pdfdocs/Plib_ASCII.pdf
 
         # for now, let's make the outline 4 pitches larger than the bump array
-        outline_width = ((bumps.x + 3) * pitch)
-        outline_height = ((bumps.y + 3) * pitch)
+        outline_width = ((bumps.x + 3) * pitch_x)
+        outline_height = ((bumps.y + 3) * pitch_y)
 
         output = "*PADS-LIBRARY-PCB-DECALS-V9*\n\n"
         # Fields in order from left to right
@@ -216,20 +218,20 @@ class GenericPCBDeliverableTool(HammerPCBDeliverableTool):
         # we'll dog-ear the outline to indicate the reference bump in the top left
         # x and y are in mm, not um
         output += "{x} {y}\n".format(x=um2mm(-outline_width/2, 3),           y=um2mm(-outline_height/2, 3))
-        output += "{x} {y}\n".format(x=um2mm(-outline_width/2, 3),           y=um2mm( outline_height/2 - 2*pitch, 3))
-        output += "{x} {y}\n".format(x=um2mm(-outline_width/2 + 2*pitch, 3), y=um2mm( outline_height/2, 3))
+        output += "{x} {y}\n".format(x=um2mm(-outline_width/2, 3),           y=um2mm( outline_height/2 - 2*pitch_y, 3))
+        output += "{x} {y}\n".format(x=um2mm(-outline_width/2 + 2*pitch_x, 3), y=um2mm( outline_height/2, 3))
         output += "{x} {y}\n".format(x=um2mm( outline_width/2, 3),           y=um2mm( outline_height/2, 3))
         output += "{x} {y}\n".format(x=um2mm( outline_width/2, 3),           y=um2mm(-outline_height/2, 3))
         output += "{x} {y}\n".format(x=um2mm(-outline_width/2, 3),           y=um2mm(-outline_height/2, 3))
 
         # create all of the terminals
-        x_offset = ((1 - bumps.x) * pitch) / 2  # type: Decimal
-        y_offset = ((1 - bumps.y) * pitch) / 2  # type: Decimal
+        x_offset = ((1 - bumps.x) * pitch_x) / 2  # type: Decimal
+        y_offset = ((1 - bumps.y) * pitch_y) / 2  # type: Decimal
         naming_scheme = self.naming_scheme
         for bump in bumps.assignments:
             # note that the flip-chip mirroring happens here
-            x = um2mm(Decimal(str(bumps.x - bump.x)) * pitch + x_offset, 3)
-            y = um2mm(Decimal(str(bump.y - 1)) * pitch + y_offset, 3)
+            x = um2mm(Decimal(str(bumps.x - bump.x)) * pitch_x + x_offset, 3)
+            y = um2mm(Decimal(str(bump.y - 1)) * pitch_y + y_offset, 3)
             label = naming_scheme.name_bump(bumps, bump)
             output += "T{x} {y} {x} {y} {label}\n".format(x=x, y=y, label=label)
 

--- a/hammer/tech/__init__.py
+++ b/hammer/tech/__init__.py
@@ -395,6 +395,17 @@ class HammerTechnology:
             print(e)  # TODO: fix the root cause
             return None
 
+    def get_setting_suffix(self, key: str) -> Any:
+        """Get a particular setting from the database with a suffix.
+        """
+        try:
+            return self._database.get(key)
+        except AttributeError:
+            raise ValueError("Internal error: no database set by hammer-vlsi")
+        except KeyError as e:  # this function is expected to return Optional[str] from extracted_tarballs_dir()
+            print(e)  # TODO: fix the root cause
+            return None
+
     def has_setting(self, key: str) -> bool:
         """Check if a setting exists in the database.
         """

--- a/hammer/vlsi/constraints.py
+++ b/hammer/vlsi/constraints.py
@@ -240,7 +240,10 @@ BumpAssignment = NamedTuple('BumpAssignment', [
 BumpsDefinition = NamedTuple('BumpsDefinition', [
     ('x', int),
     ('y', int),
-    ('pitch', Decimal),
+    ('pitch_x', Decimal),
+    ('pitch_y', Decimal),
+    ('global_x_offset', Decimal),
+    ('global_y_offset', Decimal),
     ('cell', str),
     ('assignments', List[BumpAssignment])
 ])

--- a/hammer/vlsi/hammer_tool.py
+++ b/hammer/vlsi/hammer_tool.py
@@ -899,6 +899,19 @@ class HammerTool(metaclass=ABCMeta):
         except AttributeError:
             raise ValueError("Internal error: no database set by hammer-vlsi")
 
+    def get_setting_suffix(self, key: str, suffix: str, nullvalue: Any = None) -> Any:
+        """
+        Get a particular setting from the database with a suffix.
+
+        :param key: Key of the setting to receive.
+        :param suffix: Suffix to search for on top of the base.
+        :param nullvalue: Value to return in case of null (leave as None to use the default).
+        """
+        try:
+            return self._database.get_setting_suffix(key, suffix, nullvalue)
+        except AttributeError:
+            raise ValueError("Internal error: no database set by hammer-vlsi")
+
     def set_setting(self, key: str, value: Any) -> None:
         """
         Set a runtime setting in the database.
@@ -1091,6 +1104,15 @@ class HammerTool(metaclass=ABCMeta):
 
     def get_independent_ground_nets(self) -> List[Supply]:
         return list(filter(lambda x: x.tie is None, self.get_all_ground_nets()))
+
+    def _get_by_bump_dim_pitch(self) -> Dict[str, float]:
+        """
+        Return pitches in the x and y directions. 
+        """
+        pitch_x = self.get_setting_suffix('vlsi.inputs.bumps.pitch', 'x')
+        pitch_y = self.get_setting_suffix('vlsi.inputs.bumps.pitch', 'y')
+
+        return {'x': pitch_x, 'y': pitch_y}
 
     def get_bumps(self) -> Optional[BumpsDefinition]:
         bumps_mode = self.get_setting("vlsi.inputs.bumps_mode")

--- a/hammer/vlsi/hammer_tool.py
+++ b/hammer/vlsi/hammer_tool.py
@@ -1114,9 +1114,16 @@ class HammerTool(metaclass=ABCMeta):
             else:
                 assignments.append(BumpAssignment(name=name, no_connect=no_con,
                     x=x, y=y, group=group, custom_cell=cell))
-        return BumpsDefinition(x=self.get_setting("vlsi.inputs.bumps.x"),
+        
+        pitch_settings = self.get_by_bump_dim_pitch()
+
+        return BumpsDefinition(
+            x=self.get_setting("vlsi.inputs.bumps.x"),
             y=self.get_setting("vlsi.inputs.bumps.y"),
-            pitch=Decimal(str(self.get_setting("vlsi.inputs.bumps.pitch"))),
+            pitch_x = Decimal(str(pitch_settings['x'])),
+            pitch_y = Decimal(str(pitch_settings['y'])),
+            global_x_offset=Decimal(str(self.get_setting("vlsi.inputs.bumps.global_x_offset"))),
+            global_y_offset=Decimal(str(self.get_setting("vlsi.inputs.bumps.global_y_offset"))),
             cell=self.get_setting("vlsi.inputs.bumps.cell"), assignments=assignments)
 
     def generate_visualization(self) -> None:

--- a/hammer/vlsi/hammer_tool.py
+++ b/hammer/vlsi/hammer_tool.py
@@ -1296,11 +1296,12 @@ class HammerTool(metaclass=ABCMeta):
                 fsvg.write("</g>\n</svg>\n")
                 fsvg.close()
                 return
-            bp = bumps.pitch
+            bp_x = bumps.pitch_x
+            bp_y = bumps.pitch_y
             bump_radius = get_macro_wh(bumps.cell)[0]/2
             # Bumps API centers bumps in design
-            x_os = (top.width-(bumps.x-1)*bp)/2
-            y_os = (top.height-(bumps.y-1)*bp)/2
+            x_os = (top.width-(bumps.x-1)*bp_x)/2
+            y_os = (top.height-(bumps.y-1)*bp_y)/2
             fsvg.write('<text x="{}" y="{}" text-anchor="start" class="bold10pt">bump pitch: {}um</text>\n'.format(10, title_height/2+10, bp))
             fsvg.write('<text x="{}" y="{}" text-anchor="start" class="bold10pt">bump grid: {} x {}</text>\n'.format(10, title_height/2+30, bumps.x, bumps.y))
             bump_circles = bump_text = bump_lblx = bump_lbly = '<g transform="{}">\n'.format(translate)

--- a/hammer/vlsi/hammer_tool.py
+++ b/hammer/vlsi/hammer_tool.py
@@ -1302,7 +1302,7 @@ class HammerTool(metaclass=ABCMeta):
             # Bumps API centers bumps in design
             x_os = (top.width-(bumps.x-1)*bp_x)/2
             y_os = (top.height-(bumps.y-1)*bp_y)/2
-            fsvg.write('<text x="{}" y="{}" text-anchor="start" class="bold10pt">bump pitch: {}um</text>\n'.format(10, title_height/2+10, bp))
+            fsvg.write('<text x="{}" y="{}" text-anchor="start" class="bold10pt">bump pitch x: {}um</text>\n'.format(10, title_height/2+10, bp_x))
             fsvg.write('<text x="{}" y="{}" text-anchor="start" class="bold10pt">bump grid: {} x {}</text>\n'.format(10, title_height/2+30, bumps.x, bumps.y))
             bump_circles = bump_text = bump_lblx = bump_lbly = '<g transform="{}">\n'.format(translate)
 
@@ -1318,10 +1318,10 @@ class HammerTool(metaclass=ABCMeta):
                 elif b.name in [g.name for g in g_nets]:
                     bump_type = 'ground'
 
-                b_x = x_os+Decimal(str(b.x-1))*bp
+                b_x = x_os+Decimal(str(b.x-1))*bp_x
                 if is_pcb_tool: # mirror about y-axis
                     b_x = top.width - b_x
-                b_y = top.height-y_os-Decimal(str(b.y-1))*bp
+                b_y = top.height-y_os-Decimal(str(b.y-1))*bp_y
 
                 bump_circles += '<circle cx="{}" cy="{}" r="{}" class="{}" />\n'.format(b_x, b_y, bump_radius, bump_type)
                 if viz_mode == "bumps" or not is_pcb_tool: # don't print pad designator also
@@ -1335,13 +1335,13 @@ class HammerTool(metaclass=ABCMeta):
 
             # Mark every 5th bump (helpful for large chips)
             for i in range(4, bumps.x, 5):
-                lbl_x = x_os+i*bp
+                lbl_x = x_os+i*bp_x
                 if is_pcb_tool: # mirror about y-axis
                     lbl_x = top.width - lbl_x
                 bump_lblx += '<text text-anchor="middle" x="{}" y="{}" class="bold12pt">{}</text>\n'.format(lbl_x, top.height-10, i+1)
                 bump_lblx += '<text text-anchor="middle" x="{}" y="{}" class="bold12pt">{}</text>\n'.format(lbl_x, 15, i+1)
             for i in range(4, bumps.y, 5):
-                lbl_y = top.height-y_os-i*bp
+                lbl_y = top.height-y_os-i*bp_y
                 bump_lbly += '<text text-anchor="start" x="{}" y="{}" class="bold12pt">{}</text>\n'.format(5, lbl_y, i+1)
                 bump_lbly += '<text text-anchor="end" x="{}" y="{}" class="bold12pt">{}</text>\n'.format(top.width-5, lbl_y, i+1)
 

--- a/hammer/vlsi/hammer_tool.py
+++ b/hammer/vlsi/hammer_tool.py
@@ -1115,7 +1115,7 @@ class HammerTool(metaclass=ABCMeta):
                 assignments.append(BumpAssignment(name=name, no_connect=no_con,
                     x=x, y=y, group=group, custom_cell=cell))
         
-        pitch_settings = self.get_by_bump_dim_pitch()
+        pitch_settings = self._get_by_bump_dim_pitch()
 
         return BumpsDefinition(
             x=self.get_setting("vlsi.inputs.bumps.x"),

--- a/hammer/vlsi/hammer_vlsi_impl.py
+++ b/hammer/vlsi/hammer_vlsi_impl.py
@@ -804,6 +804,32 @@ class HammerPlaceAndRouteTool(HammerTool):
         consumed_tracks = 2 * track_width + track_spacing
         return round(consumed_tracks / power_utilization)
 
+    def _get_by_bump_dim_setting(self, key: str, dim_name: str) -> Any:
+        """
+        Return bump settings based on the dimension.
+        :param key: The base key name (e.g., pitch). Do not include the namespace or metal override
+        :param dim_name: Provide a dimensional argument (x, y, z!)
+        """
+        default  = "vlsi.inputs.bumps." + key
+        override = default + "_" + "dim_name"
+
+        try:
+            return self.get_setting(override)
+        except KeyError:
+            try:
+                return self.get_setting(default)
+            except KeyError:
+                raise ValueError("No value set for key {}".format(default))        
+
+    def get_by_bump_dim_pitch(self) -> Dict[str, float]:
+        """
+        Return pitches in the x and y directions. 
+        """
+        pitch_x = self._get_by_bump_dim_setting('pitch', 'x')
+        pitch_y = self._get_by_bump_dim_setting('pitch', 'y')
+
+        return {'x': pitch_x, 'y': pitch_y}
+
     @abstractmethod
     def specify_power_straps(self, layer_name: str, bottom_via_layer_name: str, blockage_spacing: Decimal, pitch: Decimal, width: Decimal, spacing: Decimal, offset: Decimal, bbox: Optional[List[Decimal]], nets: List[str], add_pins: bool) -> List[str]:
         """

--- a/hammer/vlsi/hammer_vlsi_impl.py
+++ b/hammer/vlsi/hammer_vlsi_impl.py
@@ -775,15 +775,8 @@ class HammerPlaceAndRouteTool(HammerTool):
         :param key: The base key name (e.g. track_spacing). Do not include the namespace or metal override.
         :return: The value associated with the key, after applying any metal overrides
         """
-        default = "par.generate_power_straps_options.by_tracks." + key
-        override = default + "_" + layer_name
-        try:
-            return self.get_setting(override)
-        except KeyError:
-            try:
-                return self.get_setting(default)
-            except KeyError:
-                raise ValueError("No value set for key {}".format(default))
+        key = "par.generate_power_straps_options.by_tracks." + key
+        return self.get_setting_suffix(key, layer_name)
 
     def _get_by_tracks_track_pitch(self, layer_name: str) -> int:
         """
@@ -803,32 +796,6 @@ class HammerPlaceAndRouteTool(HammerTool):
         # This strategy uses pairs of power and ground
         consumed_tracks = 2 * track_width + track_spacing
         return round(consumed_tracks / power_utilization)
-
-    def _get_by_bump_dim_setting(self, key: str, dim_name: str) -> Any:
-        """
-        Return bump settings based on the dimension.
-        :param key: The base key name (e.g., pitch). Do not include the namespace or metal override
-        :param dim_name: Provide a dimensional argument (x, y, z!)
-        """
-        default  = "vlsi.inputs.bumps." + key
-        override = default + "_" + dim_name
-
-        try:
-            return self.get_setting(override)
-        except KeyError:
-            try:
-                return self.get_setting(default)
-            except KeyError:
-                raise ValueError("No value set for key {}".format(default))        
-
-    def _get_by_bump_dim_pitch(self) -> Dict[str, float]:
-        """
-        Return pitches in the x and y directions. 
-        """
-        pitch_x = self._get_by_bump_dim_setting('pitch', 'x')
-        pitch_y = self._get_by_bump_dim_setting('pitch', 'y')
-
-        return {'x': pitch_x, 'y': pitch_y}
 
     @abstractmethod
     def specify_power_straps(self, layer_name: str, bottom_via_layer_name: str, blockage_spacing: Decimal, pitch: Decimal, width: Decimal, spacing: Decimal, offset: Decimal, bbox: Optional[List[Decimal]], nets: List[str], add_pins: bool) -> List[str]:
@@ -891,30 +858,6 @@ class HammerSignoffTool(HammerTool):
         :return: The number of signoff issues raised by the tool
         """
         pass
-
-class DummyParTool(HammerPlaceAndRouteTool):
-    """
-    This is a dummy implementation of PAR tool.
-    """
-
-    def fill_outputs(self) -> bool:
-        return True
-
-    def specify_power_straps(self, layer_name: str, bottom_via_layer_name: str, blockage_spacing: Decimal, pitch: Decimal, width: Decimal, spacing: Decimal, offset: Decimal, bbox: Optional[List[Decimal]], nets: List[str], add_pins: bool) -> List[str]:
-        return []
-
-    @property
-    def specify_std_cell_power_straps(self, blockage_spacing: Decimal, bbox: Optional[List[Decimal]], nets: List[str]) -> List[str]:
-        return []
-    def tool_config_prefix(self) -> str:
-        return ""
-
-    def version_number(self, version: str) -> int:
-        return 1
-
-    @property
-    def steps(self) -> List[HammerToolStep]:
-        return []
 
 class HammerDRCTool(HammerSignoffTool):
 

--- a/hammer/vlsi/hammer_vlsi_impl.py
+++ b/hammer/vlsi/hammer_vlsi_impl.py
@@ -821,7 +821,7 @@ class HammerPlaceAndRouteTool(HammerTool):
             except KeyError:
                 raise ValueError("No value set for key {}".format(default))        
 
-    def get_by_bump_dim_pitch(self) -> Dict[str, float]:
+    def _get_by_bump_dim_pitch(self) -> Dict[str, float]:
         """
         Return pitches in the x and y directions. 
         """
@@ -891,6 +891,30 @@ class HammerSignoffTool(HammerTool):
         :return: The number of signoff issues raised by the tool
         """
         pass
+
+class DummyParTool(HammerPlaceAndRouteTool):
+    """
+    This is a dummy implementation of PAR tool.
+    """
+
+    def fill_outputs(self) -> bool:
+        return True
+
+    def specify_power_straps(self, layer_name: str, bottom_via_layer_name: str, blockage_spacing: Decimal, pitch: Decimal, width: Decimal, spacing: Decimal, offset: Decimal, bbox: Optional[List[Decimal]], nets: List[str], add_pins: bool) -> List[str]:
+        return []
+
+    @property
+    def specify_std_cell_power_straps(self, blockage_spacing: Decimal, bbox: Optional[List[Decimal]], nets: List[str]) -> List[str]:
+        return []
+    def tool_config_prefix(self) -> str:
+        return ""
+
+    def version_number(self, version: str) -> int:
+        return 1
+
+    @property
+    def steps(self) -> List[HammerToolStep]:
+        return []
 
 class HammerDRCTool(HammerSignoffTool):
 

--- a/hammer/vlsi/hammer_vlsi_impl.py
+++ b/hammer/vlsi/hammer_vlsi_impl.py
@@ -811,7 +811,7 @@ class HammerPlaceAndRouteTool(HammerTool):
         :param dim_name: Provide a dimensional argument (x, y, z!)
         """
         default  = "vlsi.inputs.bumps." + key
-        override = default + "_" + "dim_name"
+        override = default + "_" + dim_name
 
         try:
             return self.get_setting(override)

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -10,12 +10,12 @@ import pytest
 import hammer.config as hammer_config
 from hammer.utils import add_dicts
 from hammer.tech import MacroSize
-from hammer.vlsi import DummyHammerTool, DummyParTool
+from hammer.vlsi import DummyHammerTool
 from hammer.vlsi.constraints import DelayConstraint, ClockPort, PinAssignment, PinAssignmentError, \
     PinAssignmentSemiAutoError, PlacementConstraint, PlacementConstraintType, Margins, \
     BumpAssignment, BumpsDefinition, BumpsPinNamingScheme, DecapConstraint
 from hammer.vlsi.units import TimeValue, CapacitanceValue
-
+from hammer.par.mockpar import MockPlaceAndRoute
 
 class TestClockConstraint:
     def check_src(self, yaml_src: str, ref_port: ClockPort) -> None:
@@ -192,22 +192,6 @@ class TestBumps:
 
         definition = BumpsDefinition(x=8421,y=8421, pitch_x=Decimal("1.23"), pitch_y=Decimal("3.14"), global_x_offset=0, global_y_offset=0, cell="bumpcell",assignments=assignments)
         assert BumpsPinNamingScheme.A1.name_bump(definition, assignments[0]) == "AAAA8421"
-
-    def test_get_by_bump_dim_setting(self) -> None:
-        """
-        Test that we can extract a bump related key by dimensionality.
-        Note that the dimension is not optional because the underlying code now requires x, y.
-        """
-        db = hammer_config.HammerDatabase()
-        db.update_project([{"vlsi.inputs.bumps.pitch": 1}, {"vlsi.inputs.bumps.pitch_b_x": 2}])
-        tool = DummyParTool()
-        tool.set_database(db)
-
-        pitch_x = tool._get_by_bump_dim_setting('pitch', 'x')
-        assert pitch_x == 1
-
-        pitch_x = tool._get_by_bump_dim_setting('pitch_b', 'x')
-        assert pitch_x == 2
         
     def test_get_by_bump_dim_pitch(self) -> None:
         """
@@ -215,7 +199,7 @@ class TestBumps:
         """
         db = hammer_config.HammerDatabase()
         db.update_project([{"vlsi.inputs.bumps.pitch": 1}])
-        tool = DummyParTool()
+        tool = MockPlaceAndRoute()
         tool.set_database(db)
 
         pitch_set = tool._get_by_bump_dim_pitch()

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -387,6 +387,8 @@ export lol=abc"cat"
                      "y": 14,
                      "pitch": 200,
                      "cell": "MY_REDACTED_BUMP_CELL",
+                     "global_x_offset": 1,
+                     "global_y_offset": 1,
                      "assignments": [
                          {"name": "reset", "x": 5, "y": 3},
                          {"no_connect": true, "x": 5, "y": 4},


### PR DESCRIPTION
Bumps previously assume same x, y pitch.  This updates bumps such that:

- Dimensions are now acceptable arguments for pitch key (i.e., `vlsi.inputs.bumps.pitch`, `vlsi.inputs.bumps.pitch_x`, `vlsi.inputs.bumps.pitch_y` are now **all** acceptable).
- Global bump offset is available for unaligned bumps (e.g., `vlsi.inputs.bumps.global_x_offset`)
- Corresponding backend tool updates.
- Fixed PCB tool to adopt this scheme.
- Fixed visualization to deal with pitch.

See: https://github.com/ucb-bar/hammer-cadence-plugins/pull/87