### PR TITLE
use HAMMER logger, fix ruamel indents

### DIFF
--- a/hammer/config/config_src.py
+++ b/hammer/config/config_src.py
@@ -17,7 +17,7 @@ from functools import lru_cache, reduce
 from typing import (Any, Callable, Dict, Iterable, List, NamedTuple, Optional,
                     Set, Tuple, Union)
 
-from hammer.logging import HammerVLSILogging
+from hammer.logging import HammerVLSILogging, HammerVLSILoggingContext
 from hammer.utils import add_dicts, deepdict, topological_sort
 
 from .yaml2json import load_yaml  # grumble grumble

--- a/hammer/config/config_src.py
+++ b/hammer/config/config_src.py
@@ -6,20 +6,22 @@
 
 # pylint: disable=invalid-name
 import importlib.resources
-from decimal import Decimal
-from typing import Iterable, List, Union, Callable, Any, Dict, Set, NamedTuple, Tuple, Optional
-from warnings import warn
-from enum import Enum
-from importlib import resources
-
-from hammer.utils import deepdict, add_dicts, topological_sort
-from .yaml2json import load_yaml  # grumble grumble
-
-from functools import reduce, lru_cache
 import json
 import numbers
 import os
 import re
+from decimal import Decimal
+from enum import Enum
+from importlib import resources
+from functools import lru_cache, reduce
+from typing import (Any, Callable, Dict, Iterable, List, NamedTuple, Optional,
+                    Set, Tuple, Union)
+
+from hammer.logging import HammerVLSILogging
+from hammer.utils import add_dicts, deepdict, topological_sort
+
+from .yaml2json import load_yaml  # grumble grumble
+
 
 # A helper class that writes Decimals as strings
 # TODO(ucb-bar/hammer#378) get rid of this and serialize units
@@ -693,6 +695,8 @@ class HammerDatabase:
 
         self.defaults = {}  # type: dict
 
+        self.logger = HammerVLSILogging().context()  # type: HammerVLSILoggingContext
+
     @property
     def runtime(self) -> List[dict]:
         return [self._runtime]
@@ -754,7 +758,7 @@ class HammerDatabase:
         if key not in self.get_config():
             raise KeyError("Key " + key + " is missing")
         if key not in self.defaults:
-            warn(f"Key {key} does not have a default implementation")
+            self.logger.warning(f"Key {key} does not have a default implementation")
         if check_type:
             self.check_setting(key)
         value = self.get_config()[key]
@@ -782,7 +786,7 @@ class HammerDatabase:
                 raise KeyError(f"Both base key: {default} and overriden key: {override} are missing.")
 
         if default not in self.defaults:
-            warn(f"Base key: {default} does not have a default implementation")
+            self.logger.warning(f"Base key: {default} does not have a default implementation")
         if check_type:
             self.check_setting(default)
         return nullvalue if value is None else value
@@ -849,7 +853,7 @@ class HammerDatabase:
         if cfg is None:
             cfg = self.get_config()
         if key not in self.get_config_types():
-            warn(f"Key {key} is not associated with a type")
+            self.logger.warning(f"Key {key} is not associated with a type")
             return True
         try:
             exp_value_type = parse_setting_type(self.get_config_types()[key])
@@ -976,7 +980,7 @@ class HammerDatabase:
         if check_type:
             for k, v in loaded_cfg.items():
                 if not self.has_setting(k):
-                    warn(f"Key {k} has a type {v} is not yet implemented")
+                    self.logger.warning(f"Key {k} has a type {v} is not yet implemented")
                 elif k != "_config_path":
                     self.check_setting(k)
 

--- a/hammer/vlsi/cli_driver.py
+++ b/hammer/vlsi/cli_driver.py
@@ -10,7 +10,6 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-import warnings
 import importlib.resources
 
 import ruamel.yaml
@@ -69,7 +68,7 @@ def dump_config_to_json_file(output_path: str, config: dict) -> None:
     with open(output_path, "w") as f:
         f.write(json.dumps(config, cls=HammerJSONEncoder, indent=4))
 
-def dump_config_to_yaml_file(output_path: str, config: Any) -> None:
+def dump_config_to_yaml_file(output_path: str, config: dict) -> None:
     """
     Helper function to dump the given config in YAML form
     to the given output path while overwriting it if it already exists.
@@ -77,7 +76,7 @@ def dump_config_to_yaml_file(output_path: str, config: Any) -> None:
     :param config: Config dictionary to dump
     """
     yaml = ruamel.yaml.YAML()
-    yaml.indent(offset=2)
+    yaml.indent(offset=2, sequence=4)
     with open(output_path, 'w') as f:
         yaml.dump(config, f)
 
@@ -328,13 +327,13 @@ class CLIDriver:
                         next_level = curr_level[key]
                         break
                     except KeyError:
-                        print(f"ERROR: Key {key} could not be found at the current level, try again.")
+                        driver.log.error(f"Key {key} could not be found at the current level, try again.")
                 overall_key.append(key)
                 if not isinstance(next_level, ruamel.yaml.CommentedMap):
                     flat_key = '.'.join(overall_key)
                     if not driver.database.has_setting(flat_key):
                         val = curr_level.get(key)
-                        warnings.warn(f"{flat_key} is not in the project configuration, the default value is displayed.")
+                        driver.log.warning(f"{flat_key} is not in the project configuration, the default value is displayed.")
                     else:
                         val = driver.database.get_setting(flat_key)
                     if key in curr_level.ca.items:
@@ -356,7 +355,7 @@ class CLIDriver:
                             break
                         if continue_input.lower() == 'n':
                             return driver.project_config
-                        print("Please input either [y]es or [n]o.")
+                        driver.log.error("Please input either [y]es or [n]o.")
                     break
                 curr_level = next_level
 


### PR DESCRIPTION
This employs the use of the HAMMER logger for warnings in both the config type warnings and the info action. It also fixes the type hinting and indentation of YAML dumped by ruamel.yaml.