### PR TITLE
New Method For Getting Timing Libs

### DIFF
--- a/hammer/config/defaults.yml
+++ b/hammer/config/defaults.yml
@@ -93,6 +93,10 @@ vlsi.technology:
   # If this is not specified, then the tarballs will be extracted to obj/<tech_dir>/extracted/.
 
   timing_lib_pref: "NLDM"
+  # Select a timing lib preference, available options include:
+  # NLDM, ECSM, and CCS (lower or upper case acceptable). 
+  # If no preference is specified, then the following preference order is followed:
+  # NLDM -> ECSM -> CCS
 
 # General VLSI inputs.
 # These will vary per run of hammer-vlsi.

--- a/hammer/config/defaults.yml
+++ b/hammer/config/defaults.yml
@@ -92,6 +92,8 @@ vlsi.technology:
   # the extracted contents of foobar.tar.gz.
   # If this is not specified, then the tarballs will be extracted to obj/<tech_dir>/extracted/.
 
+  timing_lib_pref: "NLDM"
+
 # General VLSI inputs.
 # These will vary per run of hammer-vlsi.
 vlsi.inputs:

--- a/hammer/config/defaults_types.yml
+++ b/hammer/config/defaults_types.yml
@@ -63,6 +63,9 @@ vlsi.technology:
   # Path where tarballs have been extracted.
   extracted_tarballs_dir: Optional[str]
 
+  # A preference for the timing lib.
+  timing_lib_pref: str
+
 # General VLSI inputs.
 # These will vary per run of hammer-vlsi.
 vlsi.inputs:

--- a/hammer/tech/__init__.py
+++ b/hammer/tech/__init__.py
@@ -1258,6 +1258,45 @@ class LibraryFilterHolder:
             is_file=True
         )
 
+    def get_timing_lib_with_preference(self, lib_pref: str = "NLDM") -> LibraryFilter:
+        """
+        Select ASCII .lib timing libraries. Prefers NLDM, then ECSM, then CCS if multiple are present for
+        a single given .lib.
+        """
+        lib_pref = lib_pref.upper() 
+
+        def paths_func(lib: Library) -> List[str]:
+            pref_list = ["NLDM", "ECSM", "CCS"]
+            index = None
+            
+            try:
+                index = pref_list.index(lib_pref)
+            except: 
+                raise ValueError("Library preference must be one of NLDM, ECSM, or CCS.")
+            pref_list.insert(0, pref_list.pop(index))
+
+            for elem in pref_list: 
+                if elem == "NLDM":
+                    if lib.nldm_liberty_file is not None:
+                        return [lib.nldm_liberty_file]
+                elif elem == "ECSM":
+                    if lib.ecsm_liberty_file is not None:
+                        return [lib.ecsm_liberty_file]
+                elif elem == "CCS":
+                    if lib.ccs_liberty_file is not None:
+                        return [lib.ccs_liberty_file]
+                else:
+                    pass
+                
+            return []
+
+        return LibraryFilter(
+            tag="timing_lib_with_nldm",
+            description="ECSM/CCS/NLDM timing lib (liberty ASCII .lib)",
+            paths_func=paths_func,
+            is_file=True
+        )
+
     @property
     def qrc_tech_filter(self) -> LibraryFilter:
         """


### PR DESCRIPTION
- Introduce a new method `get_timing_lib_with_preference` to allow users to select their timing lib of choice when multiple are available. This defaults to NLDM -> ECSM -> CCS. 
- New key `vlsi.technology.timing_lib_pref`.
- Backing unit test.

Note that the prior `get_timing_lib_with_ecsm_filter` is unaltered as it is used in yosys and sky plugins.

Cadence Changes here: https://github.com/ucb-bar/hammer-cadence-plugins/pull/88
