### PR TITLE
Chipyard compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ dist/
 /DVEfiles
 /opendatabase.log
 
+# e2e outputs
+e2e/obj_dir
+e2e/build*
+e2e/output.json

--- a/doc/Technology/Tech-json.rst
+++ b/doc/Technology/Tech-json.rst
@@ -24,10 +24,6 @@ The user may supply the PDK to Hammer as an already extracted directory and/or a
     {
       "id": "$STDCELLS",
       "path": "technology.asap7.stdcell_install_dir"
-    },
-    {
-      "path": "tech-asap7-cache",
-      "base var": ""
     }
   ],
   "tarballs": [

--- a/e2e/configs/sky130-test.yml
+++ b/e2e/configs/sky130-test.yml
@@ -74,6 +74,4 @@ vlsi.core.sim_tool: "hammer.sim.vcs"
 vlsi.core.power_tool: "hammer.power.voltus"
 
 # SRAM Compiler compiler options
-vlsi.core.sram_generator_tool: "sram_compiler"
-vlsi.core.sram_generator_tool_path: ["hammer/src/hammer-vlsi/technology/sky130"]
-vlsi.core.sram_generator_tool_path_meta: "append"
+vlsi.core.sram_generator_tool: "hammer.technology.sky130.sram_compiler"

--- a/e2e/pdks/asap7-a.yml
+++ b/e2e/pdks/asap7-a.yml
@@ -6,7 +6,7 @@ synthesis.genus.version: "211"
 par.innovus.version: "211"
 
 sim.vcs.version: "S-2021.09-SP1-1"
-sim.vcs.verdi_home: "/ecad/tools/synopsys/verdi/S-2021.09-SP1-1"
+sim.vcs.verdi_home: "/ecad/tools/synopsys/verdi/${sim.vcs.version}"
 sim.vcs.verdi_home_meta: lazysubst
 
 lvs.calibre.version: "2022.2_24.16"

--- a/e2e/pdks/asap7-bwrc.yml
+++ b/e2e/pdks/asap7-bwrc.yml
@@ -3,9 +3,9 @@ technology.asap7.pdk_install_dir: "/tools/B/asap7/asap7PDK_r1p7"
 technology.asap7.stdcell_install_dir: "/tools/B/asap7/asap7sc7p5t_27"
 technology.asap7.tarball_dir: "/tools/B/asap7/"
 
-synthesis.genus.version: "201"
-par.innovus.version: "191_ISR3"
+synthesis.genus.version: "211"
+par.innovus.version: "211"
 
-sim.vcs.version: "P-2019.06-SP2-5"
-sim.vcs.verdi_home: "/tools/synopsys/verdi/P-2019.06-SP2-12"
+sim.vcs.version: "S-2021.09-SP1-1"
+sim.vcs.verdi_home: "/tools/synopsys/verdi/${sim.vcs.version}"
 sim.vcs.verdi_home_meta: lazysubst

--- a/e2e/pdks/sky130-bwrc.yml
+++ b/e2e/pdks/sky130-bwrc.yml
@@ -1,6 +1,7 @@
 vlsi.core.technology: "hammer.technology.sky130"
 technology.sky130:
   sky130A: "/tools/commercial/skywater/local/sky130A"
+  sky130_nda: "/tools/commercial/skywater/swtech130/skywater-src-nda-20221031"
 
 synthesis.genus.version: "201"
 par.innovus.version: "191_ISR3"

--- a/e2e/pdks/sky130-bwrc.yml
+++ b/e2e/pdks/sky130-bwrc.yml
@@ -12,6 +12,6 @@ sim.vcs.verdi_home: "/tools/synopsys/verdi/${sim.vcs.version}"
 sim.vcs.verdi_home_meta: lazysubst
 
 synthesis.yosys.yosys_bin: "/users/nayiri/conda/envs/yosys/bin/yosys"
-par.openroad.openroad_bin: "/tools/B/tools/OpenROAD/OpenROAD_20221028/local/bin/openroad"
+par.openroad.openroad_bin: "/users/nayiri/conda/envs/openroad/bin/openroad"
 drc.magic.magic_bin: "/tools/C/nayiri/installs/bin/magic"
 lvs.netgen.netgen_bin: "/tools/B/nayiri/installs/netgen/bin/netgen"

--- a/e2e/pdks/sky130-bwrc.yml
+++ b/e2e/pdks/sky130-bwrc.yml
@@ -1,6 +1,7 @@
 vlsi.core.technology: "hammer.technology.sky130"
 technology.sky130:
   sky130A: "/tools/commercial/skywater/local/sky130A"
+  openram_lib: "/tools/commercial/skywater/local/sky130_sram_macros"
   sky130_nda: "/tools/commercial/skywater/swtech130/skywater-src-nda-20221031"
 
 synthesis.genus.version: "201"

--- a/e2e/pdks/sky130-bwrc.yml
+++ b/e2e/pdks/sky130-bwrc.yml
@@ -4,9 +4,14 @@ technology.sky130:
   openram_lib: "/tools/commercial/skywater/local/sky130_sram_macros"
   sky130_nda: "/tools/commercial/skywater/swtech130/skywater-src-nda-20221031"
 
-synthesis.genus.version: "201"
-par.innovus.version: "191_ISR3"
+synthesis.genus.version: "211"
+par.innovus.version: "211"
 
-sim.vcs.version: "P-2019.06-SP2-5"
-sim.vcs.verdi_home: "/tools/synopsys/verdi/P-2019.06-SP2-12"
+sim.vcs.version: "S-2021.09-SP1-1"
+sim.vcs.verdi_home: "/tools/synopsys/verdi/${sim.vcs.version}"
 sim.vcs.verdi_home_meta: lazysubst
+
+synthesis.yosys.yosys_bin: "/users/nayiri/conda/envs/yosys/bin/yosys"
+par.openroad.openroad_bin: "/tools/B/tools/OpenROAD/OpenROAD_20221028/local/bin/openroad"
+drc.magic.magic_bin: "/tools/C/nayiri/installs/bin/magic"
+lvs.netgen.netgen_bin: "/tools/B/nayiri/installs/netgen/bin/netgen"

--- a/hammer/par/openroad/__init__.py
+++ b/hammer/par/openroad/__init__.py
@@ -106,7 +106,7 @@ class OpenROADPlaceAndRoute(OpenROADPlaceAndRouteTool):
         # Write a checkpoint to disk.
         self.verbose_append("write_db pre_{step}".format(step=next.name))
         # Symlink the database to latest for open_chip script later.
-        self.append("ln -sfn pre_{step} latest".format(step=next.name))
+        self.append("exec ln -sfn pre_{step} latest".format(step=next.name))
         self._step_transitions = self._step_transitions + [(prev.name, next.name)]
         return True
 
@@ -129,7 +129,7 @@ class OpenROADPlaceAndRoute(OpenROADPlaceAndRouteTool):
             last = "post_{step}".format(step=self._step_transitions[-1][1])
             self.verbose_append("write_db {last}".format(last=last))
             # Symlink the database to latest for open_chip script later.
-            self.verbose_append("ln -sfn {last} latest".format(last=last))
+            self.verbose_append("exec ln -sfn {last} latest".format(last=last))
 
         return self.run_openroad()
 

--- a/hammer/par/openroad/defaults_types.yml
+++ b/hammer/par/openroad/defaults_types.yml
@@ -33,7 +33,7 @@ par.openroad:
 
   # Optional: OpenRCX RC tech file
   # Should be set in technology plugin
-  openrcx_techfile: Optional[list[str]]
+  openrcx_techfile: Optional[str]
 
   # Optional: KLayout tech file
   # Should be set in technology plugin

--- a/hammer/tech/__init__.py
+++ b/hammer/tech/__init__.py
@@ -314,8 +314,7 @@ class HammerTechnology:
     def expand_tech_cache_path(self, path) -> str:
         """ Replace occurrences of the cache directory's basename with
             the full path to the cache dir."""
-        cache_dir_basename = os.path.basename(self.cache_dir)
-        return path.replace(cache_dir_basename, self.cache_dir)
+        return path.replace("cache", self.cache_dir)
 
     # @classmethod
     def ensure_dirs_exist(self, path) -> None:

--- a/hammer/technology/sky130/__init__.py
+++ b/hammer/technology/sky130/__init__.py
@@ -7,6 +7,7 @@ import re
 import os, shutil
 from pathlib import Path
 from typing import NamedTuple, List, Optional, Tuple, Dict, Set, Any
+import importlib
 
 import hammer.tech
 from hammer.tech import HammerTechnology
@@ -144,7 +145,7 @@ class SKY130Tech(HammerTechnology):
                         (source_path, dest_path))
                     df.write(matcher.sub("", sf.read()))
                     df.write(LVS_DECK_INSERT_LINES)
-    
+
     def get_tech_par_hooks(self, tool_name: str) -> List[HammerToolHookAction]:
         hooks = {
             "openroad": [
@@ -153,7 +154,7 @@ class SKY130Tech(HammerTechnology):
             "innovus": [
             HammerTool.make_post_insertion_hook("init_design",      sky130_innovus_settings),
             HammerTool.make_pre_insertion_hook("place_tap_cells",   sky130_add_endcaps),
-            HammerTool.make_pre_insertion_hook("power_straps",      sky130_connect_nets),            
+            HammerTool.make_pre_insertion_hook("power_straps",      sky130_connect_nets),
             HammerTool.make_pre_insertion_hook("write_design",      sky130_connect_nets2)
             ]}
         return hooks.get(tool_name, [])
@@ -303,11 +304,11 @@ add_endcaps
 def sky130_set_wire_rc(ht: HammerTool) -> bool:
     assert isinstance(ht, HammerPlaceAndRouteTool), "set wire rc only for par"
     assert isinstance(ht, TCLTool), "set wire rc can only run on TCL tools"
-    sky130_plugin_path=ht.get_setting('vlsi.core.technology_path')[-1]
+    rc_file=importlib.resources.files("hammer.technology.sky130") / "extra/sky130hd.rc"
     ht.append(f"""
 ################################################################
 # Repair max slew/cap/fanout violations and normalize slews
-source {sky130_plugin_path}/sky130/extra/sky130hd.rc
+source {rc_file}
 set_wire_rc -signal -layer "met2"
 set_wire_rc -clock  -layer "met5"
     """)

--- a/hammer/technology/sky130/defaults.yml
+++ b/hammer/technology/sky130/defaults.yml
@@ -99,7 +99,7 @@ par.inputs:
 par.openroad:
   openrcx_techfile: "extra/sky130hd.rcx_rules"
   openrcx_techfile_meta: prependlocal
-  klayout_techfile_source: "${technology.sky130.sky130A}/libs.tech/klayout/sky130A.lyt"
+  klayout_techfile_source: "${technology.sky130.sky130A}/libs.tech/klayout/tech/sky130A.lyt"
   klayout_techfile_source_meta: lazysubst
 
 par.power_straps_mode: generate # Power Straps

--- a/hammer/vlsi/hammer_vlsi_impl.py
+++ b/hammer/vlsi/hammer_vlsi_impl.py
@@ -118,15 +118,17 @@ class HammerVLSISettings:
             HammerVLSISettings.get_config()
         ])
 
-        # Read in core defaults.
-        database.update_core(*hammer_config.load_config_from_defaults("hammer.config", types=True))
-
-        # Read in vendor-common defaults.
-        # TODO: move these defaults into respective vendor plugin packages
-        for pkg in ["hammer.common.cadence", "hammer.common.synopsys", "hammer.common.mentor", "hammer.common.openroad"]:
+        # Read in core and vendor-common defaults.
+        # TODO: vendor-common defaults should be in respective vendor plugin packages
+        # and considered tool configs instead
+        core_defaults = []  # type: List[dict]
+        core_defaults_types = []  # type: List[dict]
+        vendors = ["cadence", "synopsys", "mentor", "openroad"]
+        for pkg in ["hammer.config"] + list(map(lambda v: "hammer.common." + v, vendors)):
             config, types = hammer_config.load_config_from_defaults(pkg, types=True)
-            database.update_defaults(config)
-            database.update_types(types, check_type=False)
+            core_defaults.extend(config)
+            core_defaults_types.extend(types)
+        database.update_core(core_defaults, core_defaults_types)
 
 from .hammer_tool import HammerTool, HammerToolStep
 


### PR DESCRIPTION
Small fixes for Chipyard compatibility:
- `cache` directory parsing in tech JSON
- vendor defaults need to be added to the config database
- bump some things in the e2e flow
- sky130 + openroad fixes

TODO: 
- [x] ~Yosys cannot parse CIRCT output netlists, so Sky130 + open-source tools is not yet fully tested.~