### PR TITLE
Issue & PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,70 @@
+name: Bug Report
+description: File a bug report
+labels: ["bug"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Background work
+      description: Yes, I searched the following areas for a prior solution and this is the right place to post it.
+      options:
+        - label: Yes, I searched the [documentation](https://hammer-vlsi.readthedocs.io/)
+          required: true
+        - label: Yes, I searched in the [Support (Q&A)](https://github.com/ucb-bar/hammer/discussions/categories/support-q-a) section of the Discussions and read the [posting guidelines](https://github.com/ucb-bar/hammer/discussions/717)
+          required: true
+        - label: Yes, I searched [prior issues](https://github.com/ucb-bar/hammer/issues?q=)
+          required: true
+        - label: This issue is specific to Hammer, i.e., does not belong in a plugin repository instead
+          required: true
+        - label: My report does not contain sensitive info (e.g., PDK information under NDA)
+          required: true
+        - label: (If applicable) Yes, I searched the [Chipyard documentation](https://chipyard.readthedocs.io/)
+        - label: (If applicable) Yes, I searched the [Chipyard mailing list](https://groups.google.com/forum/#!forum/chipyard)
+        - label: (If applicable) Yes, I searched the [Chipyard issues](https://github.com/ucb-bar/chipyard/issues?q=)
+
+  - type: textarea
+    attributes:
+      label: Hammer version and plugin hashes
+      description: Repository and external plugin versions for reproducability
+      placeholder: Version + Hash
+      value: |
+        Release: 1.0.0
+        Hash: a1b2c3
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Other Setup
+      description: Any setup that is relevant
+      placeholder: Other setup
+      value: |
+        Ex: OS information, steps taken, documentation followed, etc.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: A concise description of what you're experiencing.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A concise description of what you expect to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Other Information
+      description: Other information needed to understand/reproduce the issue.
+      placeholder: |
+        Log files (remember to sanitize it of any sensitive info)
+        Input Hammer IR
+        Related issues/discussions
+        Suggestions on fixes
+        Tip: you can drag files into this text area
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Hammer Discussions
+    url: https://github.com/ucb-bar/hammer/discussions
+    about: Please use this for general support and feature talk.
+  - name: Chipyard Mailing List
+    url: https://groups.google.com/forum/#!forum/chipyard
+    about: If you are using Chipyard, this may be the more applicable place to ask/answer questions.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,29 @@
+name: Feature Request
+description: File a feature request
+labels: ["enhancement"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Background Work
+      description: Yes, I searched the following areas for a prior feature/solution.
+      options:
+        - label: Yes, I searched the [Development](https://github.com/ucb-bar/hammer/discussions/categories/development) section of the Discussions and have read the [posting guidelines](https://github.com/ucb-bar/hammer/discussions/717)
+          required: true
+        - label: Yes, I searched the [documentation](https://hammer-vlsi.readthedocs.io/)
+          required: true
+        - label: This feature is specific to Hammer, i.e., does not belong in a plugin repository instead
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Feature Description
+      description: Description of desired feature.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Motivating Example
+      description: A concise example demonstrating the feature.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
+
+**Related PRs / Issues**
+<!-- List any related PRs/issues here, if applicable -->
+
+<!-- choose one -->
+**Type of change**:
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Other enhancement
+
+<!-- choose one -->
+**Impact**:
+- [ ] Change to core Hammer
+- [ ] Change to a Hammer plugin
+- [ ] Other
+
+<!-- must be filled out completely to be considered for merging -->
+**Contributor Checklist**:
+- [ ] Did you set `master` as the base branch?
+- [ ] Did you state the type-of-change/impact?
+- [ ] Did you delete any extraneous prints/debugging code?
+- [ ] (If applicable) Did you add documentation for the feature?
+- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
+- [ ] (If applicable) Did you add a unit test demonstrating the PR?
+- [ ] (If applicable) Did you run this through the e2e integration tests?
+- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?


### PR DESCRIPTION
In light of the new discussions posting guidelines, I have also generated issue & PR templates modeled off of the Chipyard ones.
You can see (mostly) what the issue templates look like by clicking on each yml file [here](https://github.com/ucb-bar/hammer/tree/issue_template/.github/ISSUE_TEMPLATE).