### PR TITLE
Fix readthedocs pages for plugins

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
+<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
 
 **Related PRs / Issues**
 <!-- List any related PRs/issues here, if applicable -->

--- a/doc/CAD-Tools/OpenROAD.md
+++ b/doc/CAD-Tools/OpenROAD.md
@@ -1,0 +1,1 @@
+../../hammer/par/openroad/README.md

--- a/doc/CAD-Tools/OpenROAD.rst
+++ b/doc/CAD-Tools/OpenROAD.rst
@@ -1,1 +1,0 @@
-.. include:: ../../hammer/par/openroad/README.md

--- a/doc/Technology/ASAP7.md
+++ b/doc/Technology/ASAP7.md
@@ -1,0 +1,1 @@
+../../hammer/technology/asap7/README.md

--- a/doc/Technology/ASAP7.rst
+++ b/doc/Technology/ASAP7.rst
@@ -1,1 +1,0 @@
-.. include:: ../../hammer/technology/asap7/README.md

--- a/doc/Technology/Nangate45.md
+++ b/doc/Technology/Nangate45.md
@@ -1,0 +1,1 @@
+../../hammer/technology/nangate45/README.md

--- a/doc/Technology/Nangate45.rst
+++ b/doc/Technology/Nangate45.rst
@@ -1,1 +1,0 @@
-.. include:: ../../hammer/technology/nangate45/README.md

--- a/doc/Technology/Sky130.md
+++ b/doc/Technology/Sky130.md
@@ -1,0 +1,1 @@
+../../hammer/technology/sky130/README.md

--- a/doc/Technology/Sky130.rst
+++ b/doc/Technology/Sky130.rst
@@ -1,1 +1,0 @@
-.. include:: ../../hammer/technology/sky130/README.md


### PR DESCRIPTION
<-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
Previously, I didn't include markdown pages correctly for readthedocs. Now, myst_parser is able to render it correctly. For example, see this difference:
Old: https://hammer-vlsi.readthedocs.io/en/latest/Technology/Sky130.html
New: https://hammer-vlsi.readthedocs.io/en/fix_myst/Technology/Sky130.html

Also fix the helper text in this PR template ^ (should not appear)

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [X] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] Change to core Hammer
- [ ] Change to a Hammer plugin
- [X] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `master` as the base branch?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
