### PR TITLE
Add missing keys to defaults

### DIFF
--- a/hammer/config/defaults.yml
+++ b/hammer/config/defaults.yml
@@ -60,6 +60,12 @@ vlsi.technology:
   bump_block_cut_layer: null # Top cut/via layer for blockage under bumps. (Optional[str])
   # Only used if using vlsi.inputs.bumps
   # TODO: remove this after stackup supports vias ucb-bar/hammer#354
+  
+  tap_cell_interval: 10.0 # Spacing between columns of tap cells (float)
+  # Must be overridden by technology plugin defaults or else you will have DRC/latch-up errors.
+
+  tap_cell_offset: 0.0 # Offset of the first column of tape cells from the edge of the floorplan (float)
+  # Should be overridden by technology plugin defaults.
 
   extra_libraries: [] # Extra semiconductor IP libraries/stdcell libs/hard macros. (List[ExtraLibrary])
   # Used for non-technology-vendor-provided custom IP blocks.

--- a/hammer/config/defaults_types.yml
+++ b/hammer/config/defaults_types.yml
@@ -52,6 +52,14 @@ vlsi.technology:
   # Top cut/via layer for blockage under bumps. (Optional[str])
   bump_block_cut_layer: Optional[str]
 
+  # Spacing between columns of tap cells
+  # type: float
+  tap_cell_interval: float
+
+  # Offset of the first column of tape cells from the edge of the floorplan
+  # type: float
+  tap_cell_offset: float 
+
   # Extra semiconductor IP libraries/stdcell libs/hard macros. (List[ExtraLibrary])
   # ExtraLibrary is serialized as a list[dict[str, str]]
   # TODO: Extralibrary does not have a clean JSON serialization as of late


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
Exhaustively searched in plugins/Hammer core, only found these 2 keys to not be defined in defaults.

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->
Closes #716

<!-- choose one -->
**Type of change**:
- [X] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [X] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [X] Did you set `master` as the base branch?
- [X] Did you state the type-of-change/impact?
- [X] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
