### PR TITLE
Added UPF Support

### DIFF
--- a/hammer/config/defaults.yml
+++ b/hammer/config/defaults.yml
@@ -294,7 +294,7 @@ vlsi.inputs:
   # Specifies what kind/version/type of power specification to use
   # Valid options:
   # cpf - Use the common power format commonly used in Cadence tools
-  # upf - Use the universal power format, IEEE 1801-2015
+  # upf - Use the universal power format, IEEE 1801-2009
   power_spec_contents: null # Optional: Contents of a power specification in the above type (str)
 
   sram_parameters: [] # SRAM Parameters


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
Added UPF support to hammer. Generates a single power domain UPF. It should do exactly what hasCPFsupport does. Tested it by running PAR on the tapeout vlsi lab and manually feeding into innovus with the innovus command below:
read_power_intent -1801 power_spec.upf
[power_spec.pdf](https://github.com/ucb-bar/hammer/files/11116390/power_spec.pdf)
.

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [X] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [X] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [X] Did you set `master` as the base branch?
- [X] Did you state the type-of-change/impact?
- [X] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
