### PR TITLE
lvs config_runset key

### DIFF
--- a/hammer/lvs/icv/__init__.py
+++ b/hammer/lvs/icv/__init__.py
@@ -182,7 +182,7 @@ class ICVLVS(HammerLVSTool, SynopsysTool):
                 f.write(" -I " + " -I ".join(include_dirs))
 
             # Config runset file
-            config_rs = self.get_setting("drc.icv.config_runset")  # type: Optional[str]
+            config_rs = self.get_setting("lvs.icv.config_runset")  # type: Optional[str]
             if config_rs is not None:
                 f.write(" -config_runset" + config_rs)
         return True


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
Small fix to the config_runset key used in lvs flow.
**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] Change to core Hammer
- [X] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [X] Did you set `master` as the base branch?
- [X] Did you state the type-of-change/impact?
- [X] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
