### PR TITLE
QoL to run view_drc within the generated-scripts

### DIFF
--- a/hammer/drc/icv/__init__.py
+++ b/hammer/drc/icv/__init__.py
@@ -82,7 +82,7 @@ class ICVDRC(HammerDRCTool, SynopsysTool):
         with open(self.view_drc_script, "w") as f:
             f.write("""
         cd {run_dir}
-        source enter
+        source ./enter
         # Start Synopsys IC Validator WorkBench and wait for port to open before starting VUE
         {icvwb} -socket {port} -run {macrofile} {gds} &
         while ! nc -z localhost {port}; do

--- a/hammer/lvs/icv/__init__.py
+++ b/hammer/lvs/icv/__init__.py
@@ -92,7 +92,7 @@ class ICVLVS(HammerLVSTool, SynopsysTool):
         with open(self.view_lvs_script, "w") as f:
             f.write("""
         cd {run_dir}
-        source enter
+        source ./enter
         # Start Synopsys IC Validator WorkBench and wait for port to open before starting VUE
         {icvwb} -socket {port} -run {macrofile} {gds} &
         while ! nc -z localhost {port}; do


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
Users are manually changing the view_drc script to make it run from the generated-scritps directory. QoL improvement. 
**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] Change to core Hammer
- [ ] Change to a Hammer plugin
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
