### PR TITLE
KLayout DRC plugin

### DIFF
--- a/hammer/drc/klayout/__init__.py
+++ b/hammer/drc/klayout/__init__.py
@@ -1,0 +1,104 @@
+# Klayout DRC plugin for Hammer
+#
+# See LICENSE for licence details.
+
+import os
+from textwrap import dedent as dd
+from typing import List, Optional, Dict, Any
+
+from hammer.logging import HammerVLSILogging
+from hammer.utils import deepdict
+from hammer.vlsi import HammerToolStep
+from hammer.vlsi import HammerDRCTool, TCLTool
+
+class Klayout(HammerDRCTool, TCLTool):
+
+    #=========================================================================
+    # overrides from parent classes
+    #=========================================================================
+    @property
+    def steps(self) -> List[HammerToolStep]:
+        return self.make_steps_from_methods([
+            # no steps
+        ])
+
+    def do_post_steps(self) -> bool:
+        assert super().do_post_steps()
+        return self.run_klayout()
+
+    @property
+    def env_vars(self) -> Dict[str, str]:
+        new_dict = deepdict(super().env_vars)
+        return new_dict
+
+    def fill_outputs(self) -> bool:
+        return True
+    
+    def tool_config_prefix(self) -> str:
+        return "drc.magic"
+
+    def drc_results_pre_waived(self) -> Dict[str, int]:
+        return {}
+
+    def globally_waived_drc_rules(self) -> List[str]:
+        return []
+
+    def version_number(self, version:str) -> int:
+        """Get version from klayout bin"""
+        version = self.run_executable([self.get_setting("drc.klayout.klayout_bin"), "-v"])
+        return int(version.replace(".", ""))
+
+    @property
+    def generated_scripts_dir(self) -> str:
+        return os.path.join(self.run_dir, "generated-scripts")
+
+    @property
+    def view_drc_script(self) -> str:
+        return os.path.join(self.generated_scripts_dir, "view_drc")
+    
+    @property 
+    def report_name(self) -> str:
+        return os.path.join(self.run_dir, f"{self.top_module}.lydrc")
+
+    #=========================================================================
+    # useful subroutines
+    #=========================================================================
+
+    def run_klayout(self) -> bool:
+        drc_decks = self.get_drc_decks()
+        if len(drc_decks) == 0 or len(drc_decks) > 1:
+            self.logger.error("None or more than 1 tech file (DRC deck) found. Klayout only supports 1.")
+
+        klayout_bin = self.get_setting('drc.klayout.klayout_bin')
+        args = [
+            klayout_bin,
+            "-b", # batch mode    
+            "-r", drc_decks[0].path, # Execute main script on startup (after having loaded files etc.)
+            # script variables:
+            "-rd", f"input={self.layout_file}",
+            "-rd", f"report={self.report_name}",
+        ]
+        """
+        Create view_drc script. This opens interactive window but has to run DRC
+        all over again because there is no DRC database that can be loaded in.
+        """
+        os.makedirs(self.generated_scripts_dir, exist_ok=True)
+        lyp_file = self.get_setting('drc.klayout.layout_properties_file')
+        lyp_arg = "" if lyp_file is None else f"-l {lyp_file}"
+        with open(self.view_drc_script, "w") as f:
+            f.write(dd(f"""
+            cd {self.run_dir}
+            {klayout_bin} {self.layout_file} -m {self.report_name} {lyp_arg}
+            #   -m: load RDB (report database) file (into previous layout view)
+            """))
+        os.chmod(self.view_drc_script, 0o755)
+
+        if bool(self.get_setting("drc.klayout.generate_only")):
+            self.logger.info("Generate-only mode: command-line is " + \
+                             " ".join(args))
+        else:
+            self.run_executable(args, cwd=self.run_dir) # TODO: check for errors
+
+        return True
+
+tool = Klayout

--- a/hammer/drc/klayout/__init__.py
+++ b/hammer/drc/klayout/__init__.py
@@ -58,7 +58,7 @@ class Klayout(HammerDRCTool, TCLTool):
     
     @property 
     def report_name(self) -> str:
-        return os.path.join(self.run_dir, f"{self.top_module}.lydrc")
+        return os.path.join(self.run_dir, f"klayout-drc_results-{self.top_module}.rpt")
 
     #=========================================================================
     # useful subroutines
@@ -72,11 +72,10 @@ class Klayout(HammerDRCTool, TCLTool):
         klayout_bin = self.get_setting('drc.klayout.klayout_bin')
         args = [
             klayout_bin,
-            "-b", # batch mode    
+            "-b", # batch mode
             "-r", drc_decks[0].path, # Execute main script on startup (after having loaded files etc.)
-            # script variables:
-            "-rd", f"input={self.layout_file}",
-            "-rd", f"report={self.report_name}",
+            "-rd", f"input={self.layout_file}", # script variables
+            "-rd", f"report={self.report_name}", # drc report
         ]
         """
         Create view_drc script. This opens interactive window but has to run DRC

--- a/hammer/drc/klayout/__init__.py
+++ b/hammer/drc/klayout/__init__.py
@@ -57,7 +57,7 @@ class Klayout(HammerDRCTool, TCLTool):
         return os.path.join(self.generated_scripts_dir, "view_drc")
     
     @property 
-    def report_name(self) -> str:
+    def drc_report_name(self) -> str:
         return os.path.join(self.run_dir, f"klayout-drc_results-{self.top_module}.rpt")
 
     #=========================================================================
@@ -75,11 +75,10 @@ class Klayout(HammerDRCTool, TCLTool):
             "-b", # batch mode
             "-r", drc_decks[0].path, # Execute main script on startup (after having loaded files etc.)
             "-rd", f"input={self.layout_file}", # script variables
-            "-rd", f"report={self.report_name}", # drc report
+            "-rd", f"report={self.drc_report_name}", # drc report
         ]
         """
-        Create view_drc script. This opens interactive window but has to run DRC
-        all over again because there is no DRC database that can be loaded in.
+        Create view_drc script. This opens interactive window and loads DRC database.
         """
         os.makedirs(self.generated_scripts_dir, exist_ok=True)
         lyp_file = self.get_setting('drc.klayout.layout_properties_file')
@@ -87,8 +86,7 @@ class Klayout(HammerDRCTool, TCLTool):
         with open(self.view_drc_script, "w") as f:
             f.write(dd(f"""
             cd {self.run_dir}
-            {klayout_bin} {self.layout_file} -m {self.report_name} {lyp_arg}
-            #   -m: load RDB (report database) file (into previous layout view)
+            {klayout_bin} {self.layout_file} -m {self.drc_report_name} {lyp_arg}
             """))
         os.chmod(self.view_drc_script, 0o755)
 

--- a/hammer/drc/klayout/default_types.yml
+++ b/hammer/drc/klayout/default_types.yml
@@ -7,6 +7,4 @@ drc.klayout:
 
   generate_only: bool
 
-  technology_file: Optional[str]
-
   layout_properties_file: Optional[str]

--- a/hammer/drc/klayout/default_types.yml
+++ b/hammer/drc/klayout/default_types.yml
@@ -1,0 +1,12 @@
+# Default types of all of the configuration options for Klayout's tools
+#   specified in defaults.yml
+drc.klayout:
+  klayout_bin: str
+  
+  version: str
+
+  generate_only: bool
+
+  technology_file: Optional[str]
+
+  layout_properties_file: Optional[str]

--- a/hammer/drc/klayout/defaults.yml
+++ b/hammer/drc/klayout/defaults.yml
@@ -1,0 +1,13 @@
+# Configuration options and defaults for klayout DRC.
+# The values specified in this file are the defaults.
+drc.klayout:
+  klayout_bin: "klayout" # Change this if klayout is not on your PATH.
+  
+  version: "dummy-value" # this is just to make hammer happy (although, it is never called AFAICT).
+  # the version is actually calculated by the Klayout class
+
+  generate_only: false # Generate the run script but do not run it yet.
+
+  layout_properties_file: null # Optional: KLayout layer properties file
+  # Should be set in technology plugin
+  # type: Optional[str]

--- a/hammer/par/openroad/__init__.py
+++ b/hammer/par/openroad/__init__.py
@@ -1417,6 +1417,12 @@ class OpenROADPlaceAndRoute(OpenROADPlaceAndRouteTool):
                 for line in sf:
                     if "<lef-files>merged.lef</lef-files>" in line:
                         continue
+                    if '<no-zero-length-paths>' in line:
+                        """ we want to disallow zero length paths (i.e. convert to a polygon instead)
+                            otherwise calibre throws an error during DRC/LVS
+                            but setting this flag to 'true' doesn't seem to work
+                        """
+                        line = line.replace('<no-zero-length-paths>false','<no-zero-length-paths>true')
                     if '</lefdef>' in line:
                         df.write(insert_lines)
                     df.write(line)

--- a/hammer/power/joules/__init__.py
+++ b/hammer/power/joules/__init__.py
@@ -81,11 +81,10 @@ class Joules(HammerPowerTool, CadenceTool):
         # Replace . to / formatting in case argument passed from sim tool
         tb_dut = self.tb_dut.replace(".", "/")
 
-        # We are switching working directories and Joules still needs to find paths.
-        abspath_input_files = list(map(lambda name: os.path.join(os.getcwd(), name), self.input_files))  # type: List[str]
+
         if self.level == FlowLevel.RTL:
             # Read in the design files
-            verbose_append("read_hdl -sv {}".format(" ".join(abspath_input_files)))
+            verbose_append("read_hdl -sv {}".format(" ".join(self.input_files)))
 
         # Setup the power specification
         power_spec_arg = self.map_power_spec_name()
@@ -104,7 +103,7 @@ class Joules(HammerPowerTool, CadenceTool):
             verbose_append("elaborate {TOP_MODULE}".format(TOP_MODULE=top_module))
         elif self.level == FlowLevel.SYN:
             # Read in the synthesized netlist
-            verbose_append("read_netlist {}".format(" ".join(abspath_input_files)))
+            verbose_append("read_netlist {}".format(" ".join(self.input_files)))
 
             # Read in the post-synth SDCs
             verbose_append("read_sdc {}".format(self.sdc))
@@ -122,7 +121,6 @@ class Joules(HammerPowerTool, CadenceTool):
         # Generate average power report for all waveforms
         waveforms = self.waveforms
         for i, waveform in enumerate(waveforms):
-            waveform = os.path.join(os.getcwd(), waveform)
             verbose_append("read_stimulus -file {WAVE} -dut_instance {TB}/{DUT} -alias {WAVE_NAME}_{NUM} -append".format(WAVE=waveform, TB=tb_name, DUT=tb_dut, WAVE_NAME=os.path.basename(waveform), NUM=i))
 
         # Generate Specified and Custom Reports
@@ -130,7 +128,6 @@ class Joules(HammerPowerTool, CadenceTool):
 
         for i, report in enumerate(reports):
             waveform = os.path.basename(report.waveform_path)
-            waveform = os.path.join(os.getcwd(), waveform)
 
             read_stim_cmd = "read_stimulus -file {WAVE_PATH} -dut_instance {TB}/{DUT} -append".format(WAVE_PATH=report.waveform_path, TB=tb_name, DUT=tb_dut)
 

--- a/hammer/power/joules/__init__.py
+++ b/hammer/power/joules/__init__.py
@@ -81,10 +81,11 @@ class Joules(HammerPowerTool, CadenceTool):
         # Replace . to / formatting in case argument passed from sim tool
         tb_dut = self.tb_dut.replace(".", "/")
 
-
+        # We are switching working directories and Joules still needs to find paths.
+        abspath_input_files = list(map(lambda name: os.path.join(os.getcwd(), name), self.input_files))  # type: List[str]
         if self.level == FlowLevel.RTL:
             # Read in the design files
-            verbose_append("read_hdl -sv {}".format(" ".join(self.input_files)))
+            verbose_append("read_hdl -sv {}".format(" ".join(abspath_input_files)))
 
         # Setup the power specification
         power_spec_arg = self.map_power_spec_name()
@@ -103,7 +104,7 @@ class Joules(HammerPowerTool, CadenceTool):
             verbose_append("elaborate {TOP_MODULE}".format(TOP_MODULE=top_module))
         elif self.level == FlowLevel.SYN:
             # Read in the synthesized netlist
-            verbose_append("read_netlist {}".format(" ".join(self.input_files)))
+            verbose_append("read_netlist {}".format(" ".join(abspath_input_files)))
 
             # Read in the post-synth SDCs
             verbose_append("read_sdc {}".format(self.sdc))
@@ -121,6 +122,7 @@ class Joules(HammerPowerTool, CadenceTool):
         # Generate average power report for all waveforms
         waveforms = self.waveforms
         for i, waveform in enumerate(waveforms):
+            waveform = os.path.join(os.getcwd(), waveform)
             verbose_append("read_stimulus -file {WAVE} -dut_instance {TB}/{DUT} -alias {WAVE_NAME}_{NUM} -append".format(WAVE=waveform, TB=tb_name, DUT=tb_dut, WAVE_NAME=os.path.basename(waveform), NUM=i))
 
         # Generate Specified and Custom Reports
@@ -128,6 +130,7 @@ class Joules(HammerPowerTool, CadenceTool):
 
         for i, report in enumerate(reports):
             waveform = os.path.basename(report.waveform_path)
+            waveform = os.path.join(os.getcwd(), waveform)
 
             read_stim_cmd = "read_stimulus -file {WAVE_PATH} -dut_instance {TB}/{DUT} -append".format(WAVE_PATH=report.waveform_path, TB=tb_name, DUT=tb_dut)
 

--- a/hammer/technology/sky130/__init__.py
+++ b/hammer/technology/sky130/__init__.py
@@ -35,8 +35,8 @@ class SKY130Tech(HammerTechnology):
 
 
     def setup_cdl(self) -> None:
-        ''' Only for Calibre LVS
-            Copy and hack the cdl, replacing pfet_01v8_hvt/nfet_01v8 with phighvt/nshort
+        ''' Copy and hack the cdl, replacing pfet_01v8_hvt/nfet_01v8 with 
+            respective names in LVS deck
         '''
         setting_dir = self.get_setting("technology.sky130.sky130A")
         setting_dir = Path(setting_dir)

--- a/hammer/technology/sky130/__init__.py
+++ b/hammer/technology/sky130/__init__.py
@@ -34,8 +34,10 @@ class SKY130Tech(HammerTechnology):
         print('Loaded Sky130 Tech')
 
 
-    # Copy and hack the cdl, replacing pfet_01v8_hvt/nfet_01v8 with phighvt/nshort
     def setup_cdl(self) -> None:
+        ''' Only for Calibre LVS
+            Copy and hack the cdl, replacing pfet_01v8_hvt/nfet_01v8 with phighvt/nshort
+        '''
         setting_dir = self.get_setting("technology.sky130.sky130A")
         setting_dir = Path(setting_dir)
         source_path = setting_dir / 'libs.ref' / self.library_name / 'cdl' / f'{self.library_name}.cdl'
@@ -46,13 +48,24 @@ class SKY130Tech(HammerTechnology):
         os.makedirs(cache_tech_dir_path, exist_ok=True)
         dest_path = cache_tech_dir_path / f'{self.library_name}.cdl'
 
+        # device names expected in LVS decks
+        if (self.get_setting('vlsi.core.lvs_tool') == "hammer.lvs.calibre"):
+            pmos = 'phighvt'
+            nmos = 'nshort'
+        elif (self.get_setting('vlsi.core.lvs_tool') == "hammer.lvs.netgen"):
+            pmos = 'sky130_fd_pr__pfet_01v8_hvt'
+            nmos = 'sky130_fd_pr__nfet_01v8'
+        else:
+            shutil.copy2(source_path, dest_path)
+            return
+
         with open(source_path, 'r') as sf:
             with open(dest_path, 'w') as df:
                 self.logger.info("Modifying CDL netlist: {} -> {}".format
                     (source_path, dest_path))
                 for line in sf:
-                    line = line.replace('pfet_01v8_hvt', 'phighvt')
-                    line = line.replace('nfet_01v8'    , 'nshort')
+                    line = line.replace('pfet_01v8_hvt', pmos)
+                    line = line.replace('nfet_01v8'    , nmos)
                     df.write(line)
 
     # Copy and hack the verilog

--- a/hammer/technology/sky130/defaults.yml
+++ b/hammer/technology/sky130/defaults.yml
@@ -106,7 +106,7 @@ par.inputs:
   gds_map_file: "extra/sky130_lefpin.map"
   gds_map_file_meta: prependlocal
 
-par.openroad:
+par.openroad:  # openroad setup/files
   setrc_file: "extra/setRC.tcl"
   setrc_file_meta: prependlocal
   openrcx_techfiles: 
@@ -119,6 +119,10 @@ par.openroad:
   macro_placement:
     halo: [40, 40]
     orient_all: r90  # required for Sram22
+
+drc.klayout:  # klayout files
+  layout_properties_file: "${technology.sky130.sky130A}/libs.tech/klayout/tech/sky130A.lyp"
+  layout_properties_file_meta: lazysubst
 
 par.power_straps_mode: generate # Power Straps
 par.generate_power_straps_method: by_tracks

--- a/hammer/technology/sky130/sky130.tech.json
+++ b/hammer/technology/sky130/sky130.tech.json
@@ -21,7 +21,7 @@
     {
       "tool_name": "klayout",
       "deck_name": "klayout_drc",
-      "path": "$SKY130A/libs.tech/klayout/drc/sky130A_mr.drc"
+      "path": "$SKY130A/libs.tech/klayout/drc/sky130A.lydrc"
     }
   ],
   "additional_drc_text": "",

--- a/hammer/technology/sky130/sky130.tech.json
+++ b/hammer/technology/sky130/sky130.tech.json
@@ -12,19 +12,23 @@
       "path": "technology.sky130.sky130A"
     }
   ],
-  "layer_map_file": "$SKY130_NDA/s8/V2.0.1/VirtuosoOA/libs/technology_library/technology_library.layermap",
   "drc_decks": [
     {
       "tool_name": "calibre",
-      "deck_name": "all_drc",
+      "deck_name": "calibre_drc",
       "path": "$SKY130_NDA/s8/V2.0.1/DRC/Calibre/s8_drcRules"
+    },
+    {
+      "tool_name": "klayout",
+      "deck_name": "klayout_drc",
+      "path": "$SKY130A/libs.tech/klayout/drc/sky130A_mr.drc"
     }
   ],
   "additional_drc_text": "",
   "lvs_decks": [
     {
       "tool_name": "calibre",
-      "deck_name": "all_lvs",
+      "deck_name": "calibre_lvs",
       "old path": "$SKY130_NDA/s8/V2.0.1/LVS/Calibre/lvsRules_s8",
       "path": "cache/lvsControlFile_s8"
     }

--- a/hammer/vlsi/hammer_build_systems.py
+++ b/hammer/vlsi/hammer_build_systems.py
@@ -295,7 +295,7 @@ def build_makefile(driver: HammerDriver, append_error_func: Callable[[str], None
         \t$(HAMMER_EXEC) {env_confs} -p {syn_out} $(HAMMER_EXTRA_ARGS) -o {par_in} --obj_dir {obj_dir} syn-to-par
 
         redo-power-syn{suffix}:
-        \t$(HAMMER_EXEC) {env_confs} -p {power_sim_syn_in} $(HAMMER_EXTRA_ARGS) --power_rundir {power_syn_run_dir} --obj_dir {obj_dir} power{suffix}
+        \t$(HAMMER_EXEC) {env_confs} -p {power_sim_syn_in} -p {power_syn_in} $(HAMMER_EXTRA_ARGS) --power_rundir {power_syn_run_dir} --obj_dir {obj_dir} power{suffix}
 
         redo-par{suffix}:
         \t$(HAMMER_EXEC) {env_confs} -p {par_in} $(HAMMER_EXTRA_ARGS) --obj_dir {obj_dir} par{suffix}

--- a/hammer/vlsi/vendor/def2stream.py
+++ b/hammer/vlsi/vendor/def2stream.py
@@ -104,8 +104,6 @@ tech.load(tech_file)
 layoutOptions = tech.load_layout_options
 if len(layer_map) > 0:
   layoutOptions.lefdef_config.map_file = layer_map
-print("layoutOptions", layoutOptions)
-print("layer_map", layoutOptions.layer_map)
 
 # Load def file
 main_layout = pya.Layout()

--- a/hammer/vlsi/vendor/def2stream.py
+++ b/hammer/vlsi/vendor/def2stream.py
@@ -104,6 +104,8 @@ tech.load(tech_file)
 layoutOptions = tech.load_layout_options
 if len(layer_map) > 0:
   layoutOptions.lefdef_config.map_file = layer_map
+print("layoutOptions", layoutOptions)
+print("layer_map", layoutOptions.layer_map)
 
 # Load def file
 main_layout = pya.Layout()
@@ -197,6 +199,21 @@ if seal_file:
     if cell != top_cell:
       print("[INFO] Merging '{0}' as child of '{1}'".format(cell.name, top_cell.name))
       top.insert(pya.CellInstArray(cell.cell_index(), pya.Trans()))
+
+# Remove zero path lengths
+#   this in lyt file doesn't work: <no-zero-length-paths>true</no-zero-length-paths>
+print("Removing zero-length paths...")
+for cell in top_only_layout.each_cell():
+  for layer_idx in top_only_layout.layer_indexes():
+    for shape in cell.each_shape(layer_idx):
+      if shape.is_path():
+        path = shape.path
+        paths = [(p.x, p.y) for p in path.each_point()]
+        paths_unique = set(paths)
+        if len(paths_unique) < len(paths):
+          polygon = path.polygon()
+          print(f"\tlayer_index: {layer_idx},", shape)
+          shape.delete()
 
 # Write out the GDS
 print("[INFO] Writing out GDS/OAS '{0}'".format(out_file))


### PR DESCRIPTION
KLayout is the preferred DRC checker for sky130 according to efabless.
This plugin generates the same DRC errors as Calibre for both gcd and the Chipyard TinyRocket Config, in an easy-to-understand GUI.

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [x] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] Change to core Hammer
- [x] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
