### PR TITLE
Slurm job submission option for EECS151

### DIFF
--- a/hammer/config/defaults.yml
+++ b/hammer/config/defaults.yml
@@ -427,7 +427,8 @@ vlsi.inputs:
     # type: int
 
 vlsi.submit:
-  command: "local" # The submit command to use. "none", "local", or null will run on the current host. See hammer_submit_command.py for other options.
+  command: "local" # The submit command to use. "none", "local", or null will run on the current host. "lsf" and "slurm" are also supported.
+  # See hammer/vlsi/submit_command.py for all options and their associated settings.
   settings: [] # type: List[Dict[str, Dict[str, Any]]]
   # The list substitutes settings in order of appearance, and the first Dict key is the command.
   # The second dict key is the name of that command's setting, followed by whatever type it takes.

--- a/hammer/vlsi/submit_command.py
+++ b/hammer/vlsi/submit_command.py
@@ -20,7 +20,8 @@ from hammer.logging import HammerVLSILoggingContext
 from hammer.utils import add_dicts, get_or_else
 
 __all__ = ['HammerSubmitCommand', 'HammerLocalSubmitCommand',
-           'HammerLSFSettings', 'HammerLSFSubmitCommand']
+           'HammerLSFSettings', 'HammerLSFSubmitCommand',
+           'HammerSlurmSettings', 'HammerSlurmSubmitCommand']
 
 
 class HammerSubmitCommand:
@@ -333,7 +334,7 @@ class HammerSlurmSubmitCommand(HammerSubmitCommand):
         return args
 
     def submit(self, args: List[str], env: Dict[str, str],
-               logger: HammerVLSILoggingContext, cwd: str = None) -> str:
+               logger: HammerVLSILoggingContext, cwd: Optional[str] = None) -> Tuple[str, int]:
         prog_tag = self.get_program_tag(args)
 
         subprocess_format_str = 'Executing subprocess: {srun_args} {args}'
@@ -358,6 +359,7 @@ class HammerSlurmSubmitCommand(HammerSubmitCommand):
         # TODO: check errors
 
         # Refresh output directory (fixes NFS issue)
-        os.path.exists(cwd)
+        if cwd is not None:
+            os.path.exists(cwd)
 
         return output_buf, proc.returncode

--- a/hammer/vlsi/submit_command.py
+++ b/hammer/vlsi/submit_command.py
@@ -268,7 +268,7 @@ class HammerSlurmSettings(NamedTuple('HammerSlurmSettings', [
     ('srun_binary', str),
     ('num_cpus', Optional[int]),
     ('partition', Optional[str]),
-    ('extra_args', List[str])
+    ('extra_args', Optional[List[str]])
 ])):
     __slots__ = ()
 
@@ -317,7 +317,7 @@ class HammerSlurmSubmitCommand(HammerSubmitCommand):
         """
         Set the settings class variable
 
-        :param value: The HammerSlurmSettings NapedTuple to use
+        :param value: The HammerSlurmSettings NamedTuple to use
         """
         setattr(self, "_settings", value)
 

--- a/hammer/vlsi/submit_command.py
+++ b/hammer/vlsi/submit_command.py
@@ -9,6 +9,7 @@ import atexit
 import subprocess
 import termios
 import sys
+import os
 import datetime
 from abc import abstractmethod
 from functools import reduce
@@ -80,6 +81,8 @@ class HammerSubmitCommand:
             return HammerLocalSubmitCommand()
         elif submit_command_mode == "lsf":
             submit_command = HammerLSFSubmitCommand()
+        elif submit_command_mode == "slurm":
+            submit_command = HammerSlurmSubmitCommand()
         else:
             raise NotImplementedError(
                 "Submit command key for {0}: {1} is not implemented".format(
@@ -256,5 +259,105 @@ class HammerLSFSubmitCommand(HammerSubmitCommand):
                 break
         # check errors
         proc.communicate()
+
+        return output_buf, proc.returncode
+
+
+class HammerSlurmSettings(NamedTuple('HammerSlurmSettings', [
+    ('srun_binary', str),
+    ('num_cpus', Optional[int]),
+    ('partition', Optional[str]),
+    ('extra_args', List[str])
+])):
+    __slots__ = ()
+
+    @staticmethod
+    def from_setting(settings: Dict[str, Any]) -> "HammerSlurmSettings":
+        if not isinstance(settings, dict):
+            raise ValueError("Must be a dictionary")
+        try:
+            srun_binary = settings["srun_binary"]
+        except KeyError:
+            raise ValueError("Missing mandatory key srun_binary for Slurm settings.")
+        try:
+            num_cpus = settings["num_cpus"]
+        except KeyError:
+            num_cpus = None
+        try:
+            partition = settings["partition"]
+        except KeyError:
+            partition = None
+        try:
+            extra_args = settings["extra_args"]
+        except KeyError:
+            extra_args = []
+
+        return HammerSlurmSettings(
+            srun_binary=srun_binary,
+            num_cpus=num_cpus,
+            partition=partition,
+            extra_args=extra_args
+        )
+
+
+class HammerSlurmSubmitCommand(HammerSubmitCommand):
+
+    # TODO use --output to set logfile AND have stdout/stderr output
+    #      Currently there is no option to specify a log file.
+
+    @property
+    def settings(self) -> HammerSlurmSettings:
+        if not hasattr(self, "_settings"):
+            raise ValueError("Nothing set for settings yet")
+        return getattr(self, "_settings")
+
+    @settings.setter
+    def settings(self, value: HammerSlurmSettings) -> None:
+        """
+        Set the settings class variable
+
+        :param value: The HammerSlurmSettings NapedTuple to use
+        """
+        setattr(self, "_settings", value)
+
+    def read_settings(self, settings: Dict[str, Any], tool_namespace: str) -> None:  # pylint: disable=unused-argument
+        self.settings = HammerSlurmSettings.from_setting(settings)
+
+    def srun_args(self) -> List[str]:
+        args = [self.settings.srun_binary]
+        if self.settings.partition is not None:
+            args.extend(["--partition", self.settings.partition])
+        if self.settings.num_cpus is not None:
+            args.extend(["--ntasks", "%d" % self.settings.num_cpus])
+        args.extend(self.settings.extra_args)
+        return args
+
+    def submit(self, args: List[str], env: Dict[str, str],
+               logger: HammerVLSILoggingContext, cwd: str = None) -> str:
+        prog_tag = self.get_program_tag(args)
+
+        subprocess_format_str = 'Executing subprocess: {srun_args} {args}'
+        logger.debug(subprocess_format_str.format(srun_args=' '.join(self.srun_args()),
+                                                  args=' '.join(args)))
+        subprocess_logger = logger.context("Exec " + prog_tag)
+        proc = subprocess.Popen(self.srun_args() + args,
+                                shell=False, stderr=subprocess.STDOUT,
+                                stdout=subprocess.PIPE, env=env, cwd=cwd)
+
+        output_buf = ""
+        # Log output and also capture output at the same time.
+        so = proc.stdout
+        assert so is not None
+        while True:
+            line = so.readline().decode("utf-8")
+            if line != '':
+                subprocess_logger.debug(line.rstrip())
+                output_buf += line
+            else:
+                break
+        # TODO: check errors
+
+        # Refresh output directory (fixes NFS issue)
+        os.path.exists(cwd)
 
         return output_buf, proc.returncode

--- a/hammer/vlsi/submit_command.py
+++ b/hammer/vlsi/submit_command.py
@@ -291,7 +291,7 @@ class HammerSlurmSettings(NamedTuple('HammerSlurmSettings', [
         try:
             extra_args = settings["extra_args"]
         except KeyError:
-            extra_args = []
+            extra_args = None
 
         return HammerSlurmSettings(
             srun_binary=srun_binary,
@@ -330,7 +330,8 @@ class HammerSlurmSubmitCommand(HammerSubmitCommand):
             args.extend(["--partition", self.settings.partition])
         if self.settings.num_cpus is not None:
             args.extend(["--ntasks", "%d" % self.settings.num_cpus])
-        args.extend(self.settings.extra_args)
+        if self.settings.extra_args is not None:
+            args.extend(self.settings.extra_args)
         return args
 
     def submit(self, args: List[str], env: Dict[str, str],


### PR DESCRIPTION
Adding job submission via slurm (similar to LSF). 
This code was directly copied from edits made locally to the Hammer used for the EECS151 class.
The YAML config they used to run jobs via slurm was:
```
vlsi.submit.command: "slurm"
vlsi.submit.settings:
  - slurm: {srun_binary: "/home/ff/eecs151/tools-151/scripts/srun151", extra_args: []}
```

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [x] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [x] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
