### PR TITLE
Fix setting top/bottom routing layers in Innovus

### DIFF
--- a/hammer/par/innovus/__init__.py
+++ b/hammer/par/innovus/__init__.py
@@ -249,18 +249,6 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
         # Match SDC time units to timing libraries
         verbose_append("set_library_unit -time 1{}".format(self.get_time_unit().value_prefix + self.get_time_unit().unit))
 
-        # Set the top and bottom global/detail routing layers.
-        layers = self.get_setting("vlsi.technology.routing_layers")
-        if layers is not None:
-            if self.version() >= self.version_number("201"):
-                verbose_append(f"set_db design_bottom_routing_layer {layers[0]}")
-                verbose_append(f"set_db design_top_routing_layer {layers[1]}")
-            else:
-                verbose_append(f"set_db route_early_global_bottom_layer {layers[0]}")
-                verbose_append(f"set_db route_early_global_top_layer {layers[1]}")
-                verbose_append(f"set_db route_design_bottom_layer {layers[0]}")
-                verbose_append(f"set_db route_design_top_layer {layers[1]}")
-
         # Read LEF layouts.
         lef_files = self.technology.read_libs([
             hammer_tech.filters.lef_filter
@@ -312,6 +300,19 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
         # Setup power settings from cpf/upf
         for l in self.generate_power_spec_commands():
             verbose_append(l)
+
+        # Set the top and bottom global/detail routing layers.
+        # This must happen after the tech LEF is loaded
+        layers = self.get_setting("vlsi.technology.routing_layers")
+        if layers is not None:
+            if self.version() >= self.version_number("201"):
+                verbose_append(f"set_db design_bottom_routing_layer {layers[0]}")
+                verbose_append(f"set_db design_top_routing_layer {layers[1]}")
+            else:
+                verbose_append(f"set_db route_early_global_bottom_layer {layers[0]}")
+                verbose_append(f"set_db route_early_global_top_layer {layers[1]}")
+                verbose_append(f"set_db route_design_bottom_layer {layers[0]}")
+                verbose_append(f"set_db route_design_top_layer {layers[1]}")
 
         # Set design effort.
         verbose_append("set_db design_flow_effort {}".format(self.get_setting("par.innovus.design_flow_effort")))


### PR DESCRIPTION
Move setting of routing layers to the end of the `init_design` Hammer step, to after tech LEFs are loaded.

<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->
closes #793

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] Change to core Hammer
- [x] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
