### PR TITLE
Pass ILM SDCs upwards through hierarchical flow

### DIFF
--- a/hammer/config/defaults.yml
+++ b/hammer/config/defaults.yml
@@ -161,6 +161,7 @@ vlsi.inputs:
   # gds (str) - path to the GDS file
   # netlist (str) - path to the netlist file
   # sim_netlist (str) - Optional. If specified, this netlist is appended for hierarchical simulation
+  # sdcs (List(str)) - paths to the SDC file(s) needed for parent constraints
 
   mmmc_corners: [] # Multi-mode multi-corner setups, overrides supplies
   # MMMC struct members:

--- a/hammer/par/innovus/__init__.py
+++ b/hammer/par/innovus/__init__.py
@@ -519,7 +519,7 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
         if self.hierarchical_mode.is_nonleaf_hierarchical():
             self.verbose_append('''
             flatten_ilm
-            update_constraint_mode -name my_constraint_mode -sdc_files {sdc}
+            update_constraint_mode -name my_constraint_mode -ilm_sdc_files {sdc}
             '''.format(sdc=self.post_synth_sdc), clean=True)
         if len(self.get_clock_ports()) > 0:
             # Ignore clock tree when there are no clocks

--- a/hammer/par/innovus/__init__.py
+++ b/hammer/par/innovus/__init__.py
@@ -835,7 +835,7 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
             ilm_dir_name=self.ilm_dir_name))
         # Need to append -hierarchical after get_pins in SDCs for parent timing analysis
         for sdc_out in self.output_ilm_sdcs:
-            self.verbose_append('gzip -d -c {ilm_dir_name}/mmmc/ilm_data/{top}/{sdc_in}.gz | sed "s/get_pins/get_pins -hierarchical/g" > {sdc_out}'.format(
+            self.append('gzip -d -c {ilm_dir_name}/mmmc/ilm_data/{top}/{sdc_in}.gz | sed "s/get_pins/get_pins -hierarchical/g" > {sdc_out}'.format(
                 ilm_dir_name=self.ilm_dir_name, top=self.top_module, sdc_in=os.path.basename(sdc_out), sdc_out=sdc_out))
         self.ran_write_ilm = True
         return True

--- a/hammer/par/innovus/__init__.py
+++ b/hammer/par/innovus/__init__.py
@@ -517,7 +517,10 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
     def clock_tree(self) -> bool:
         """Setup and route a clock tree for clock nets."""
         if self.hierarchical_mode.is_nonleaf_hierarchical():
-            self.verbose_append("flatten_ilm")
+            self.verbose_append('''
+            flatten_ilm
+            update_constraint_mode -name my_constraint_mode -sdc_files {sdc}
+            '''.format(sdc=self.post_synth_sdc), clean=True)
         if len(self.get_clock_ports()) > 0:
             # Ignore clock tree when there are no clocks
             self.verbose_append("create_clock_tree_spec")

--- a/hammer/par/mockpar/__init__.py
+++ b/hammer/par/mockpar/__init__.py
@@ -87,12 +87,13 @@ class MockPlaceAndRoute(HammerPlaceAndRouteTool, DummyHammerTool):
         self.output_gds = "/dev/null"
         self.output_netlist = "/dev/null"
         self.output_sim_netlist = "/dev/null"
+        self.output_ilm_sdcs = ["/dev/null"]
         self.hcells_list = []
         if self.hierarchical_mode in [HierarchicalMode.Leaf, HierarchicalMode.Hierarchical]:
             self.output_ilms = [
                 ILMStruct(dir="/dev/null", data_dir="/dev/null", module=self.top_module,
                           lef="/dev/null", gds=self.output_gds, netlist=self.output_netlist,
-                          sim_netlist=self.output_sim_netlist)
+                          sim_netlist=self.output_sim_netlist, sdcs=self.output_ilm_sdcs)
             ]
         else:
             self.output_ilms = []

--- a/hammer/vlsi/constraints.py
+++ b/hammer/vlsi/constraints.py
@@ -25,7 +25,8 @@ class ILMStruct(NamedTuple('ILMStruct', [
     ('lef', str),
     ('gds', str),
     ('netlist', str),
-    ('sim_netlist', Optional[str])
+    ('sim_netlist', Optional[str]),
+    ('sdcs', List[str])
 ])):
     __slots__ = ()
 
@@ -36,7 +37,8 @@ class ILMStruct(NamedTuple('ILMStruct', [
             "module": self.module,
             "lef": self.lef,
             "gds": self.gds,
-            "netlist": self.netlist
+            "netlist": self.netlist,
+            "sdcs": self.sdcs
         }
         if self.sim_netlist is not None:
             output.update({"sim_netlist": self.sim_netlist})
@@ -51,7 +53,8 @@ class ILMStruct(NamedTuple('ILMStruct', [
             lef=str(ilm["lef"]),
             gds=str(ilm["gds"]),
             netlist=str(ilm["netlist"]),
-            sim_netlist=ilm.get("sim_netlist")
+            sim_netlist=ilm.get("sim_netlist"),
+            sdcs=list(map(lambda x: str(x), ilm["sdcs"]))
         )
 
 


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
ILM SDCs were not getting read during parent synthesis. These SDCs predominantly have `set_case_analysis` and `set_annotated_transition` commands, which are required in some cases to properly choose the proper timing mode in lib files.

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [X] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [X] Change to core Hammer
- [X] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [X] Did you set `master` as the base branch?
- [X] Did you state the type-of-change/impact?
- [X] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
