### PR TITLE
Additional Units Overhaul Fixes

### DIFF
--- a/hammer/utils/lib_utils.py
+++ b/hammer/utils/lib_utils.py
@@ -21,7 +21,7 @@ class LIBUtils:
         try:
             match = next(line for line in lines if "time_unit" in line)
             # attibute syntax: time_unit : <value><unit> ;
-            unit = re.split(" : | ; ", match)[1]
+            unit = re.split(" : | ; ", match)[1].replace('"', "").replace(";", "")
             return unit
         except StopIteration:  # should not get here
             return None

--- a/hammer/utils/lib_utils.py
+++ b/hammer/utils/lib_utils.py
@@ -21,8 +21,7 @@ class LIBUtils:
         try:
             match = next(line for line in lines if "time_unit" in line)
             # attibute syntax: time_unit : <value><unit> ;
-            unit = re.split(" : | ; ", match)[1].replace('"', "").replace(";", "")
-            return unit
+            return re.split(":|;", match)[1].strip().strip('\"')
         except StopIteration:  # should not get here
             return None
 
@@ -37,7 +36,7 @@ class LIBUtils:
             # attibute syntax: capacitive_load_unit(<value>,<unit>);
             # Also need to capitalize last f to F
             split = re.split(r"\(|,|\)", match)
-            return split[1] + split[2].strip()[:-1] + split[2].strip()[-1].upper()
+            return split[1] + split[2].strip().strip('\"')[:-1] + split[2].strip().strip('\"')[-1].upper()
         except StopIteration:  # should not get here
             return None
 


### PR DESCRIPTION
Follow-on PR to #800. 

- Units Overhaul broke ASAP7, Sky130 flow (eg. in `e2e`,  fails after parsing lib `time_unit` to `"1ps";`)
- Fixes lib `time_unit` reading
- Some more pipe-cleaning is needed to check capacitance value reading

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [x] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
