### PR TITLE
set_dont_touch on preplaced pins in SDC file

### DIFF
--- a/hammer/vlsi/hammer_vlsi_impl.py
+++ b/hammer/vlsi/hammer_vlsi_impl.py
@@ -2211,6 +2211,11 @@ class HasSDCSupport(HammerTool):
                 name=delay.name
             ))
 
+        # set_dont_touch on any preplaced pins
+        for pin in self.get_pin_assignments():
+            if pin.preplaced:
+                output.append(f"set_dont_touch [get_nets {pin.pins}]")
+
         # Custom sdc constraints that are verbatim appended
         custom_sdc_constraints = self.get_setting("vlsi.inputs.custom_sdc_constraints")  # type: Union[List[str], str]
         if isinstance(custom_sdc_constraints, str):


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
Needed so that synthesis does not insert buffers

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [X] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [X] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [X] Did you set `master` as the base branch?
- [X] Did you state the type-of-change/impact?
- [X] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
