### PR TITLE
Mocksim was missing fill_outputs()

### DIFF
--- a/hammer/sim/mocksim/__init__.py
+++ b/hammer/sim/mocksim/__init__.py
@@ -42,6 +42,17 @@ class MockSim(HammerSimTool, DummyHammerTool):
                 f.write("\n")
         return True
 
+    def fill_outputs(self) -> bool:
+        # TODO: Not sure...
+        self.output_waveforms = []
+        self.output_saifs = []
+        self.output_top_module = self.top_module
+        self.output_tb_name = ""
+        self.output_tb_dut = ""
+        self.output_level = ""
+        
+        return True
+
 
 
 tool = MockSim


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
HammerSimTool needs fill_outputs() 

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [X] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] Change to core Hammer
- [X] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [X] Did you set `master` as the base branch?
- [X] Did you state the type-of-change/impact?
- [X] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [X] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
