### PR TITLE
Add setting to control antenna_trim_shape

### DIFF
--- a/hammer/config/defaults.yml
+++ b/hammer/config/defaults.yml
@@ -603,6 +603,10 @@ par:
       # Overrideable by appending _<layer name>
       # type: float
 
+      antenna_trim_shape: stripe # "none" or "stripe", specifies antenna trimming strategy
+      # Overrideable by appending _<layer name>
+      # type: str
+
       pin_layers: [] # Layers to put power pins on
       # type: List[str]
 

--- a/hammer/config/defaults_types.yml
+++ b/hammer/config/defaults_types.yml
@@ -310,6 +310,10 @@ par:
       # type: int
       track_spacing: int
 
+      # Specifies antenna trimming strategy. none or stripe
+      # type: str
+      antenna_trim_shape: str
+
       # Ratio of total routing tracks to dedicate to power straps, which is used to calculate set pitch
       # type: float
       power_utilization: float

--- a/hammer/par/innovus/__init__.py
+++ b/hammer/par/innovus/__init__.py
@@ -1125,7 +1125,7 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
         results.append("add_stripes " + " ".join(options) + "\n")
         return results
 
-    def specify_power_straps(self, layer_name: str, bottom_via_layer_name: str, blockage_spacing: Decimal, pitch: Decimal, width: Decimal, spacing: Decimal, offset: Decimal, bbox: Optional[List[Decimal]], nets: List[str], add_pins: bool) -> List[str]:
+    def specify_power_straps(self, layer_name: str, bottom_via_layer_name: str, blockage_spacing: Decimal, pitch: Decimal, width: Decimal, spacing: Decimal, offset: Decimal, bbox: Optional[List[Decimal]], nets: List[str], add_pins: bool, antenna_trim_shape: str) -> List[str]:
         """
         Generate a list of TCL commands that will create power straps on a given layer.
         This is a low-level, cad-tool-specific API. It is designed to be called by higher-level methods, so calling this directly is not recommended.
@@ -1141,6 +1141,7 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
         :param bbox: The optional (2N)-point bounding box of the area to generate straps. By default the entire core area is used.
         :param nets: A list of power nets to create (e.g. ["VDD", "VSS"], ["VDDA", "VSS", "VDDB"],  ... etc.).
         :param add_pins: True if pins are desired on this layer; False otherwise.
+        :param antenna_trim_shape: Strategy for trimming strap antennae. {none/stripe}
         :return: A list of TCL commands that will generate power straps.
         """
         # TODO check that this has been not been called after a higher-level metal and error if so
@@ -1149,6 +1150,7 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
         results.extend([
             "set_db add_stripes_stacked_via_top_layer {}".format(layer_name),
             "set_db add_stripes_stacked_via_bottom_layer {}".format(bottom_via_layer_name),
+            "set_db add_stripes_trim_antenna_back_to_shape {{{}}}".format(antenna_trim_shape),
             "set_db add_stripes_spacing_from_block {}".format(blockage_spacing)
         ])
         layer = self.get_stackup().get_metal(layer_name)

--- a/hammer/par/mockpar/__init__.py
+++ b/hammer/par/mockpar/__init__.py
@@ -50,7 +50,7 @@ class MockPlaceAndRoute(HammerPlaceAndRouteTool, DummyHammerTool):
                 output.append(json.loads(line))
         return output
 
-    def specify_power_straps(self, layer_name: str, bottom_via_layer_name: str, blockage_spacing: Decimal, pitch: Decimal, width: Decimal, spacing: Decimal, offset: Decimal, bbox: Optional[List[Decimal]], nets: List[str], add_pins: bool) -> List[str]:
+    def specify_power_straps(self, layer_name: str, bottom_via_layer_name: str, blockage_spacing: Decimal, pitch: Decimal, width: Decimal, spacing: Decimal, offset: Decimal, bbox: Optional[List[Decimal]], nets: List[str], add_pins: bool, antenna_trim_shape: str) -> List[str]:
         self._power_straps_check_index(layer_name)
         output_dict = {
             "layer_name": layer_name,
@@ -62,7 +62,8 @@ class MockPlaceAndRoute(HammerPlaceAndRouteTool, DummyHammerTool):
             "offset": str(offset),
             "bbox": [] if bbox is None else list(map(str, bbox)),
             "nets": list(map(str, nets)),
-            "add_pins": add_pins
+            "add_pins": add_pins,
+            "antenna_trim_shape": antenna_trim_shape
         }
         return [json.dumps(output_dict, cls=HammerJSONEncoder)]
 

--- a/hammer/par/nop/__init__.py
+++ b/hammer/par/nop/__init__.py
@@ -17,7 +17,7 @@ class NopPlaceAndRoute(HammerPlaceAndRouteTool, DummyHammerTool):
         self.hcells_list = []
         return True
 
-    def specify_power_straps(self, layer_name: str, bottom_via_layer_name: str, blockage_spacing: Decimal, pitch: Decimal, width: Decimal, spacing: Decimal, offset: Decimal, bbox: Optional[List[Decimal]], nets: List[str], add_pins: bool) -> List[str]:
+    def specify_power_straps(self, layer_name: str, bottom_via_layer_name: str, blockage_spacing: Decimal, pitch: Decimal, width: Decimal, spacing: Decimal, offset: Decimal, bbox: Optional[List[Decimal]], nets: List[str], add_pins: bool, antenna_trim_shape: str) -> List[str]:
         return []
 
     def specify_std_cell_power_straps(self, blockage_spacing: Decimal, bbox: Optional[List[Decimal]], nets: List[str]) -> List[str]:

--- a/hammer/par/openroad/__init__.py
+++ b/hammer/par/openroad/__init__.py
@@ -1882,7 +1882,7 @@ class OpenROADPlaceAndRoute(OpenROADPlaceAndRouteTool):
         #  -pitch {pitch}
         return tcl
 
-    def specify_power_straps(self, layer_name: str, bottom_via_layer_name: str, blockage_spacing: Decimal, pitch: Decimal, width: Decimal, spacing: Decimal, offset: Decimal, bbox: Optional[List[Decimal]], nets: List[str], add_pins: bool) -> List[str]:
+    def specify_power_straps(self, layer_name: str, bottom_via_layer_name: str, blockage_spacing: Decimal, pitch: Decimal, width: Decimal, spacing: Decimal, offset: Decimal, bbox: Optional[List[Decimal]], nets: List[str], add_pins: bool, antenna_trim_shape: str) -> List[str]:
         """
         Generate a list of TCL commands that will create power straps on a given layer.
         This is a low-level, cad-tool-specific API. It is designed to be called by higher-level methods, so calling this directly is not recommended.
@@ -1898,6 +1898,7 @@ class OpenROADPlaceAndRoute(OpenROADPlaceAndRouteTool):
         :param bbox: The optional (2N)-point bounding box of the area to generate straps. By default the entire core area is used.
         :param nets: A list of power nets to create (e.g. ["VDD", "VSS"], ["VDDA", "VSS", "VDDB"],  ... etc.).
         :param add_pins: True if pins are desired on this layer; False otherwise.
+        :param antenna_trim_shape: Strategy for trimming strap antennae. {none/stripe}
         :return: A list of TCL commands that will generate power straps.
         """
         pdn_cfg = [f" {layer_name} {{width {width} pitch {pitch} offset {offset}}}"]

--- a/hammer/vlsi/vendor/openroad.py
+++ b/hammer/vlsi/vendor/openroad.py
@@ -251,7 +251,8 @@ class OpenROADPlaceAndRouteTool(HammerPlaceAndRouteTool, OpenROADTool):
                              bottom_via_layer_name: str, blockage_spacing: Decimal, pitch: Decimal,
                              width: Decimal, spacing: Decimal, offset: Decimal,
                              bbox: Optional[List[Decimal]], nets: List[str],
-                             add_pins: bool) -> List[str]:
+                             add_pins: bool,
+                             antenna_trim_shape: str) -> List[str]:
         # TODO: currently using openroad's powerstrap script
         return []
 


### PR DESCRIPTION
Default is stlil `stripe`, as before. This could be a way to fix some DRCs where trimming the strap back results in a bad via shape to the lower layer straps.

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [x] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [x] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
