### PR TITLE
De-uniquify hierarchical blocks in genus for hierarchical flows

### DIFF
--- a/hammer/synthesis/genus/__init__.py
+++ b/hammer/synthesis/genus/__init__.py
@@ -4,7 +4,7 @@
 
 from hammer.vlsi import HammerTool, HammerToolStep, HammerToolHookAction, HierarchicalMode
 from hammer.utils import VerilogUtils
-from hammer.vlsi import HammerSynthesisTool
+from hammer.vlsi import HammerSynthesisTool, PlacementConstraintType
 from hammer.logging import HammerVLSILogging
 from hammer.vlsi import MMMCCornerType
 import hammer.tech as hammer_tech
@@ -302,6 +302,16 @@ class Genus(HammerSynthesisTool, CadenceTool):
                 # Clock mapping needs at least the attributes cts_inverter_cells and cts_logic_cells to be set
                 self.append("set_db map_clock_tree true")
         self.verbose_append("syn_generic")
+
+        # With DDI, hierarchical instances may be uniquified. Use change_link to deuniquify them
+        if self.hierarchical_mode.is_nonleaf_hierarchical():
+            pcs = list(filter(lambda c: c.type == PlacementConstraintType.Hierarchical, self.get_placement_constraints()))
+            for pc in pcs:
+                self.append("""
+if {{ [get_db hinst:{inst} .module.name] ne \"{master}\" }} {{
+    change_link -instances {{{inst}}} -design_name module:{top}/{master}
+}}""".format(inst=pc.path, top=self.top_module, master=pc.master))
+
         return True
 
     def syn_map(self) -> bool:

--- a/hammer/synthesis/genus/__init__.py
+++ b/hammer/synthesis/genus/__init__.py
@@ -312,7 +312,7 @@ class Genus(HammerSynthesisTool, CadenceTool):
 set uniquified_name [get_db hinst:{inst} .module.name]
 if {{ $uniquified_name ne \"{master}\" }} {{
     puts [format \"WARNING: instance hinst:{inst} was uniquified to be an instance of $uniquified_name, not {master}. Attempting to fix\"]
-    change_link -instances {{{inst}}} -design_name module:{top}/{master}
+    change_link -copy_attributes -instances {{{inst}}} -design_name module:{top}/{master}
 }}""".format(inst=pc.path, top=self.top_module, master=pc.master))
 
         return True

--- a/hammer/synthesis/genus/__init__.py
+++ b/hammer/synthesis/genus/__init__.py
@@ -308,7 +308,10 @@ class Genus(HammerSynthesisTool, CadenceTool):
             pcs = list(filter(lambda c: c.type == PlacementConstraintType.Hierarchical, self.get_placement_constraints()))
             for pc in pcs:
                 self.append("""
-if {{ [get_db hinst:{inst} .module.name] ne \"{master}\" }} {{
+# Attempt to deuniquify hinst:{inst}, incase it was uniquified
+set uniquified_name [get_db hinst:{inst} .module.name]
+if {{ $uniquified_name ne \"{master}\" }} {{
+    puts [format \"WARNING: instance hinst:{inst} was uniquified to be an instance of $uniquified_name, not {master}. Attempting to fix\"]
     change_link -instances {{{inst}}} -design_name module:{top}/{master}
 }}""".format(inst=pc.path, top=self.top_module, master=pc.master))
 

--- a/hammer/synthesis/genus/__init__.py
+++ b/hammer/synthesis/genus/__init__.py
@@ -304,7 +304,7 @@ class Genus(HammerSynthesisTool, CadenceTool):
         self.verbose_append("syn_generic")
 
         # With DDI, hierarchical instances may be uniquified. Use change_link to deuniquify them
-        if self.hierarchical_mode.is_nonleaf_hierarchical():
+        if self.hierarchical_mode.is_nonleaf_hierarchical() and self.version() >= self.version_number("211"):
             pcs = list(filter(lambda c: c.type == PlacementConstraintType.Hierarchical, self.get_placement_constraints()))
             for pc in pcs:
                 self.append("""


### PR DESCRIPTION
With DDI, syn_generic uniquifies ILM module names. Prevent this by deuniquifying after syn_generic.

This also assumes that the type of hierarchical instances appears as `hierarchical` in the placement constraints.
Evidently this wasn't required before for the hierarchical flow to work correctly, but it is required for this fix to work.

<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [x] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
