### PR TITLE
Add flag to prevent power strap generation on stdcell rail layer

### DIFF
--- a/hammer/config/defaults.yml
+++ b/hammer/config/defaults.yml
@@ -613,6 +613,9 @@ par:
       strap_layers: [] # List of layers on which to place power straps (std cell rail layer is implied - do not include it)
       # type: List[str]
 
+      generate_rail_layer: true # If true, generates straps on the stdcell rail layer - technology.core.std_cell_rail_layer
+      # type: bool
+
 # DRC settings
 drc.inputs:
 # DRC settings

--- a/hammer/config/defaults_types.yml
+++ b/hammer/config/defaults_types.yml
@@ -326,6 +326,10 @@ par:
       # type: list[str]
       strap_layers: list[str]
 
+      # Indicates if Hammer should generate straps for the stdcell rail layer
+      # type: bool
+      generate_rail_layer: bool
+
 # DRC settings
 drc.inputs:
   # Top RTL module.


### PR DESCRIPTION
In some technologies, the stdcell rail layer is handled by a special tech-specific hook. This gives us more flexibility in selecting which layers show up in the auto-generated power_straps.tcl

<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [x] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [x] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
