### PR TITLE
Improvements to supplies API

### DIFF
--- a/hammer/config/defaults.yml
+++ b/hammer/config/defaults.yml
@@ -113,7 +113,7 @@ vlsi.inputs:
   # Supply voltages and names
   # Supply Struct:
   #   name (str) - The name of your supply's net
-  #   pin (Optional[str]) - The cell pin that this net should drive, no pins are connected when omitted
+  #   pins (Optional[List[str]]) - The cell pin/s that this net should drive. If None, pin name is assumed to be net name. If empty, no pins are connected
   #   tie (Optional[str]) - Another supply this supply is tied to. Nets with this set will  not end up in your final layout.
   #   weight (Optional[int]) - The weight of this supply when building power straps (larger number = more straps).
   #     Not used for grounds. Mandatory, but defaults to 1 if omitted.

--- a/hammer/config/defaults.yml
+++ b/hammer/config/defaults.yml
@@ -621,6 +621,9 @@ par:
       # Otherwise should be set to some layer name
       # type: str
 
+      power_nets: [] # List of power nets to generate straps for. If empty, generates straps for all nets in vlsi.inputs.supplies
+      # type: List[str]
+
 # DRC settings
 drc.inputs:
 # DRC settings

--- a/hammer/config/defaults.yml
+++ b/hammer/config/defaults.yml
@@ -118,8 +118,8 @@ vlsi.inputs:
   #   weight (Optional[int]) - The weight of this supply when building power straps (larger number = more straps).
   #     Not used for grounds. Mandatory, but defaults to 1 if omitted.
   supplies:
-    power: [{name: "VDD", pin: "VDD"}] # power (List(Supply)): A list of of all power net(s) in the design
-    ground: [{name: "VSS", pin: "VSS"}] # ground (List(Supply)): A list of all ground net(s) in the design
+    power: [{name: "VDD", pins: ["VDD"]}] # power (List(Supply)): A list of of all power net(s) in the design
+    ground: [{name: "VSS", pins: ["VSS"]}] # ground (List(Supply)): A list of all ground net(s) in the design
     VDD: "0.85 V" # VDD (str): The default voltage of the primary power net
     GND: "0 V" # GND (str): The default voltage of the primary ground net
 

--- a/hammer/config/defaults_types.yml
+++ b/hammer/config/defaults_types.yml
@@ -334,6 +334,10 @@ par:
       # type: str
       bottom_via_layer: str
 
+      # Indicates which power nets straps should be generated for
+      # type: list[str]
+      power_nets: list[str]
+
 # DRC settings
 drc.inputs:
   # Top RTL module.

--- a/hammer/config/defaults_types.yml
+++ b/hammer/config/defaults_types.yml
@@ -82,8 +82,8 @@ vlsi.technology:
 vlsi.inputs:
   # Supply voltages and names
   supplies:
-    power: list[dict[str, str]]
-    ground: list[dict[str, str]]
+    power: list[dict[str, Any]]
+    ground: list[dict[str, Any]]
     VDD: str
     GND: str
 

--- a/hammer/technology/sky130/defaults.yml
+++ b/hammer/technology/sky130/defaults.yml
@@ -53,14 +53,14 @@ vlsi:
   inputs:
     supplies: # Supply voltages.
     # TODO: add ability to tie pin to net in Hammer Innovus plugin
-      power:  [ {name: "VDD",  pin: "VDD"}, 
-                {name: "VPWR", pin: "VPWR", tie: "VDD"},
-                {name: "VPB",  pin: "VPB" , tie: "VDD"},
-                {name: "vdd",  pin: "vdd",  tie: "VDD"}]
-      ground: [ {name: "VSS",  pin: "VSS"},
-                {name: "VGND", pin: "VGND", tie: "VSS"},
-                {name: "VNB",  pin: "VNB" , tie: "VSS"},
-                {name: "vss",  pin: "vss",  tie: "VSS"}]
+      power:  [ {name: "VDD",  pins: ["VDD" ]},
+                {name: "VPWR", pins: ["VPWR"], tie: "VDD"},
+                {name: "VPB",  pins: ["VPB" ], tie: "VDD"},
+                {name: "vdd",  pins: ["vdd" ], tie: "VDD"}]
+      ground: [ {name: "VSS",  pins: ["VSS" ]},
+                {name: "VGND", pins: ["VGND"], tie: "VSS"},
+                {name: "VNB",  pins: ["VNB" ], tie: "VSS"},
+                {name: "vss",  pina: ["vss" ], tie: "VSS"}]
       VDD: "1.8 V"
       GND: "0 V"
 

--- a/hammer/vlsi/constraints.py
+++ b/hammer/vlsi/constraints.py
@@ -87,7 +87,7 @@ class SRAMParameters(NamedTuple('SRAMParameters', [
 
 Supply = NamedTuple('Supply', [
     ('name', str),
-    ('pins', List[str]),
+    ('pins', Optional[List[str]]),
     ('tie', Optional[str]),
     ('weight', Optional[int]),
     ('voltage', Optional[str])

--- a/hammer/vlsi/constraints.py
+++ b/hammer/vlsi/constraints.py
@@ -87,7 +87,7 @@ class SRAMParameters(NamedTuple('SRAMParameters', [
 
 Supply = NamedTuple('Supply', [
     ('name', str),
-    ('pin', Optional[str]),
+    ('pins', List[str]),
     ('tie', Optional[str]),
     ('weight', Optional[int])
 ])

--- a/hammer/vlsi/constraints.py
+++ b/hammer/vlsi/constraints.py
@@ -89,7 +89,8 @@ Supply = NamedTuple('Supply', [
     ('name', str),
     ('pins', List[str]),
     ('tie', Optional[str]),
-    ('weight', Optional[int])
+    ('weight', Optional[int]),
+    ('voltage', Optional[str])
 ])
 
 

--- a/hammer/vlsi/hammer_tool.py
+++ b/hammer/vlsi/hammer_tool.py
@@ -1090,7 +1090,7 @@ class HammerTool(metaclass=ABCMeta):
         supplies = self.get_setting(key)
         output = []  # type: List[Supply]
         for raw_supply in supplies:
-            supply = Supply(name=raw_supply['name'], pins=[], tie=None, weight=1)
+            supply = Supply(name=raw_supply['name'], pins=[], tie=None, weight=1, voltage=None)
             assert 'pin' not in raw_supply, "supply.pin: str has been replaced with supply.pins: List[str]"
             if 'pins' in raw_supply:
                 supply = supply._replace(pins=raw_supply['pins'])
@@ -1098,6 +1098,8 @@ class HammerTool(metaclass=ABCMeta):
                 supply = supply._replace(tie=raw_supply['tie'])
             if 'weight' in raw_supply:
                 supply = supply._replace(weight=raw_supply['weight'])
+            if 'voltage' in raw_supply:
+                supply = supply._replace(voltage=raw_supply['voltage'])
             output.append(supply)
         return output
 

--- a/hammer/vlsi/hammer_tool.py
+++ b/hammer/vlsi/hammer_tool.py
@@ -1090,9 +1090,10 @@ class HammerTool(metaclass=ABCMeta):
         supplies = self.get_setting(key)
         output = []  # type: List[Supply]
         for raw_supply in supplies:
-            supply = Supply(name=raw_supply['name'], pin=None, tie=None, weight=1)
-            if 'pin' in raw_supply:
-                supply = supply._replace(pin=raw_supply['pin'])
+            supply = Supply(name=raw_supply['name'], pins=[], tie=None, weight=1)
+            assert 'pin' not in raw_supply, "supply.pin: str has been replaced with supply.pins: List[str]"
+            if 'pins' in raw_supply:
+                supply = supply._replace(pins=raw_supply['pins'])
             if 'tie' in raw_supply:
                 supply = supply._replace(tie=raw_supply['tie'])
             if 'weight' in raw_supply:

--- a/hammer/vlsi/hammer_vlsi_impl.py
+++ b/hammer/vlsi/hammer_vlsi_impl.py
@@ -2091,25 +2091,28 @@ class HasUPFSupport(HammerTool):
         ground_nets = self.get_all_ground_nets()
         #Create Supply Ports
         for pg_net in (power_nets+ground_nets):
-            if len(pg_net.pins):
-                #Create Supply Nets
-                output.append(f'create_supply_net {pg_net.name} -domain {domain}')
-                output.append(f'create_supply_port {pg_net.name} -domain {domain} \\')
-                output.append(f'\t-direction in')
+            pins = pg_net.pins if pg_net.pins is not None else [pg_net.name]
+            #Create Supply Nets
+            output.append(f'create_supply_net {pg_net.name} -domain {domain}')
+            output.append(f'create_supply_port {pg_net.name} -domain {domain} \\')
+            output.append(f'\t-direction in')
+            for pin in pins:
                 #Connect Supply Net
-                output.append(f'connect_supply_net {pg_net.name} -ports {pg_net.name}')
-                #Set Domain Supply Net
+                output.append(f'connect_supply_net {pg_net.name} -ports {pin}')
+        #Set Domain Supply Net
         output.append(f'set_domain_supply_net {domain} \\')
         output.append(f'\t-primary_power_net {power_nets[0].name} \\')
         output.append(f'\t-primary_ground_net {ground_nets[0].name}')
         #Add Port States
         for p_net in power_nets:
-            if len(p_net.pins):
-                output.append(f'add_port_state {p_net.name} \\')
+            pins = p_net.pins if p_net.pins is not None else [p_net.name]
+            for pin in pins:
+                output.append(f'add_port_state {pin} \\')
                 output.append(f'\t-state {{default {vdd.value}}}')
         for g_net in ground_nets:
-            if len(g_net.pins):
-                output.append(f'add_port_state {g_net.name} \\')
+            pins = g_net.pins if g_net.pins is not None else [g_net.name]
+            for pin in pins:
+                output.append(f'add_port_state {pin} \\')
                 output.append(f'\t-state {{default 0.0}}')
         #Create Power State Table
         output.append('create_pst pwr_state_table \\')
@@ -2150,8 +2153,9 @@ class HasCPFSupport(HammerTool):
         output.append(f'update_power_domain -name {domain} -primary_power_net {power_nets[0].name} -primary_ground_net {ground_nets[0].name}')
         # Assuming that all power/ground nets correspond to pins
         for pg_net in (power_nets+ground_nets):
-            if len(pg_net.pins):
-                pins_str = ' '.join(pg_net.pins)
+            pins = pg_net.pins if pg_net.pins is not None else [pg_net.name]
+            if len(pins):
+                pins_str = ' '.join(pins)
                 output.append(f'create_global_connection -domain {domain} -net {pg_net.name} -pins [list {pins_str}]')
         # Create nominal operation condtion and power mode
         nominal_vdd = VoltageValue(self.get_setting("vlsi.inputs.supplies.VDD")) # type: VoltageValue

--- a/hammer/vlsi/hammer_vlsi_impl.py
+++ b/hammer/vlsi/hammer_vlsi_impl.py
@@ -2084,7 +2084,7 @@ class HasUPFSupport(HammerTool):
         ground_nets = self.get_all_ground_nets()
         #Create Supply Ports
         for pg_net in (power_nets+ground_nets):
-            if(pg_net.pin != None):
+            if len(pg_net.pins):
                 #Create Supply Nets
                 output.append(f'create_supply_net {pg_net.name} -domain {domain}')
                 output.append(f'create_supply_port {pg_net.name} -domain {domain} \\')
@@ -2097,11 +2097,11 @@ class HasUPFSupport(HammerTool):
         output.append(f'\t-primary_ground_net {ground_nets[0].name}')
         #Add Port States
         for p_net in power_nets:
-            if(p_net.pin != None):
+            if len(p_net.pins):
                 output.append(f'add_port_state {p_net.name} \\')
                 output.append(f'\t-state {{default {vdd.value}}}')
         for g_net in ground_nets:
-            if(g_net.pin != None):
+            if len(g_net.pins):
                 output.append(f'add_port_state {g_net.name} \\')
                 output.append(f'\t-state {{default 0.0}}')
         #Create Power State Table
@@ -2140,8 +2140,9 @@ class HasCPFSupport(HammerTool):
         output.append(f'update_power_domain -name {domain} -primary_power_net {power_nets[0].name} -primary_ground_net {ground_nets[0].name}')
         # Assuming that all power/ground nets correspond to pins
         for pg_net in (power_nets+ground_nets):
-            if(pg_net.pin != None):
-                output.append(f'create_global_connection -domain {domain} -net {pg_net.name} -pins {pg_net.pin}')
+            if len(pg_net.pins):
+                pins_str = ' '.join(pg_net.pins)
+                output.append(f'create_global_connection -domain {domain} -net {pg_net.name} -pins [list {pins_str}]')
         # Create nominal operation condtion and power mode
         output.append(f'create_nominal_condition -name {condition} -voltage {vdd.value}')
         output.append(f'create_power_mode -name {mode} -default -domain_conditions {{{domain}@{condition}}}')

--- a/tests/test_power_straps.py
+++ b/tests/test_power_straps.py
@@ -93,8 +93,8 @@ def simple_straps_options() -> Dict[str, Any]:
 
     straps_options = {
         "vlsi.inputs.supplies": {
-            "power": [{"name": "VDD", "pin": "VDD"}],
-            "ground": [{"name": "VSS", "pin": "VSS"}],
+            "power": [{"name": "VDD", "pins": ["VDD"]}],
+            "ground": [{"name": "VSS", "pins": ["VSS"]}],
             "VDD": "1.00 V",
             "GND": "0 V"
         },
@@ -129,8 +129,8 @@ def multiple_domains_straps_options() -> Dict[str, Any]:
 
     straps_options = {
         "vlsi.inputs.supplies": {
-            "power": [{"name": "VDD", "pin": "VDD"}, {"name": "VDD2", "pin": "VDD2"}],
-            "ground": [{"name": "VSS", "pin": "VSS"}],
+            "power": [{"name": "VDD", "pins": ["VDD"]}, {"name": "VDD2", "pins": ["VDD2"]}],
+            "ground": [{"name": "VSS", "pins": ["VSS"]}],
             "VDD": "1.00 V",
             "GND": "0 V"
         },


### PR DESCRIPTION
- Change `vlsi.inputs.supplies.power/ground.pin` to `.pins`. This generates CPFs with a `create_global_connection` from  single net to multiple pins
- Add `power_straps_options.by_tracks.power_nets` setting. This controls which supply nets power straps are generated for. The default uses all supplies, but this is not always desired
- Add `vlsi.input.supplies.power.voltage` field. The existing system would always create the power_nets with the same `vlsi.inputs.supplies.VDD` voltage. This enables per-supply voltage setting.


**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [x] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [x] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `master` as the base branch?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
