### PR TITLE
Add make clean

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -43,3 +43,7 @@ $(HAMMER_D_MK):
 	hammer-vlsi --obj_dir $(OBJ_DIR) -e $(ENV_YML) $(HAMMER_EXTRA_ARGS) build
 
 -include $(HAMMER_D_MK)
+
+clean:
+    rm -rf $(OBJ_DIR)
+    find $(vlsi_dir) -name 'hammer-vlsi-*.log' -delete

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -45,5 +45,4 @@ $(HAMMER_D_MK):
 -include $(HAMMER_D_MK)
 
 clean:
-    rm -rf $(OBJ_DIR)
-    find $(vlsi_dir) -name 'hammer-vlsi-*.log' -delete
+    rm -rf $(OBJ_DIR) hammer-vlsi-*.log

--- a/hammer/synthesis/genus/__init__.py
+++ b/hammer/synthesis/genus/__init__.py
@@ -224,7 +224,7 @@ class Genus(HammerSynthesisTool, CadenceTool):
         ))
 
         # Load input files and check that they are all Verilog.
-        if not self.check_input_files([".v", ".sv"]):
+        if not self.check_input_files([".v", ".sv", "vh"]):
             return False
         # We are switching working directories and Genus still needs to find paths.
         abspath_input_files = list(map(lambda name: os.path.join(os.getcwd(), name), self.input_files))  # type: List[str]


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
Added a clean rule to the e2e Makefile that deletes the build directory and all log files in the vlsi directory.

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [X] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] Change to core Hammer
- [ ] Change to a Hammer plugin
- [X] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [X] Did you set `master` as the base branch?
- [X] Did you state the type-of-change/impact?
- [X] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
