### PR TITLE
Add {redo-}hier-par-to-syn- targets to Makefile build flow

### DIFF
--- a/hammer/vlsi/hammer_build_systems.py
+++ b/hammer/vlsi/hammer_build_systems.py
@@ -484,10 +484,17 @@ def build_makefile(driver: HammerDriver, append_error_func: Callable[[str], None
                 prereqs = " ".join(out_confs)
                 pstring = " ".join(["-p " + x for x in out_confs])
                 par_to_syn = textwrap.dedent("""
+                    .PHONY: hier-par-to-syn-{node} redo-hier-par-to-syn-{node}
+
                     {syn_deps}: {prereqs}
                     \t$(HAMMER_EXEC) {env_confs} {pstring} -o {syn_deps} --obj_dir {obj_dir} hier-par-to-syn
+
+                    hier-par-to-syn-{node}: {syn_deps}
+
+                    redo-hier-par-to-syn-{node}:
+                    \t$(HAMMER_EXEC) {env_confs} {pstring} -o {syn_deps} --obj_dir {obj_dir} hier-par-to-syn
                     """.format(syn_deps=syn_deps, prereqs=prereqs, env_confs=env_confs, pstring=pstring,
-                    obj_dir=obj_dir))
+                    obj_dir=obj_dir, node=node))
 
             output += make_text.format(suffix="-"+node, mod=node, env_confs=env_confs, obj_dir=obj_dir, syn_deps=syn_deps,
                 par_to_syn=par_to_syn,

--- a/tests/test_build_systems.py
+++ b/tests/test_build_systems.py
@@ -135,6 +135,10 @@ class TestHammerBuildSystems:
             expected_targets.update({task + "-" + x for x in mods})
             expected_targets.update({"redo-" + task + "-" + x for x in mods})
 
+        # Only non-leafs get a hier-par-to-syn target
+        expected_targets.update({"hier-par-to-syn-" + x for x in mods if x in {"TopMod"}})
+        expected_targets.update({"redo-hier-par-to-syn-" + x for x in mods if x in {"TopMod"}})
+
         # Only non-leafs get a syn-*-input.json target
         expected_targets.update({os.path.join(tmpdir, "syn-" + x + "-input.json") for x in mods if x in {"TopMod"}})
         expected_targets.update({os.path.join(tmpdir, "sim-syn-" + x + "-input.json") for x in mods})


### PR DESCRIPTION
Minor QoL improvement

<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `master` as the base branch?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
