### PR TITLE
Support multiple rounds of opt_design in Innovus plugin

### DIFF
--- a/hammer/par/innovus/__init__.py
+++ b/hammer/par/innovus/__init__.py
@@ -637,7 +637,10 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
         Post-route optimization and fix setup & hold time violations.
         -expanded_views creates timing reports for each MMMC view.
         """
-        self.verbose_append("opt_design -post_route -setup -hold -expanded_views")
+        rounds = self.get_setting("par.innovus.opt_design_rounds")
+        assert rounds > 0
+        for r in range(rounds):
+            self.verbose_append("opt_design -post_route -setup -hold -expanded_views")
         if self.hierarchical_mode.is_nonleaf_hierarchical():
             self.verbose_append("unflatten_ilm")
         return True

--- a/hammer/par/innovus/defaults.yml
+++ b/hammer/par/innovus/defaults.yml
@@ -35,3 +35,7 @@ par.innovus:
   # Note that this requires an optional licence (enccco).
   # type: bool
   use_cco: true
+
+  # How many iterations to run opt_design
+  # If the first opt_design fails to converge by a small margin, the second run may achieve closure
+  opt_design_rounds: 1


### PR DESCRIPTION
Most designs should only run 1 round. 
This is very occasionally useful, and should be used judiciously 

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [x] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `master` as the base branch?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
