### PR TITLE
Fix SRAM22 `sram-cache.json` to exclude missing LEFs

### DIFF
--- a/hammer/technology/sky130/extra/sram22/sram-cache.json
+++ b/hammer/technology/sky130/extra/sram22/sram-cache.json
@@ -1,34 +1,6 @@
 [
   {
     "type": "sram",
-    "name": "sram22_4096x8m8w8",
-    "source": "sram22",
-    "depth": "4096",
-    "width": 8,
-    "family": "1rw",
-    "mask": "true",
-    "vt": "svt",
-    "mux": 8,
-    "ports": [
-      {
-        "address port name": "addr",
-        "address port polarity": "active high",
-        "clock port name": "clk",
-        "clock port polarity": "active high",
-        "write enable port name": "we",
-        "write enable port polarity": "active high",
-        "output port name": "dout",
-        "output port polarity": "active high",
-        "input port name": "din",
-        "input port polarity": "active high",
-        "mask port name": "wmask",
-        "mask granularity": 8,
-        "mask port polarity": "active high"
-      }
-    ]
-  },
-  {
-    "type": "sram",
     "name": "sram22_512x32m4w32",
     "source": "sram22",
     "depth": "512",
@@ -163,34 +135,6 @@
         "input port polarity": "active high",
         "mask port name": "wmask",
         "mask granularity": 24,
-        "mask port polarity": "active high"
-      }
-    ]
-  },
-  {
-    "type": "sram",
-    "name": "sram22_4096x32m8w8",
-    "source": "sram22",
-    "depth": "4096",
-    "width": 32,
-    "family": "1rw",
-    "mask": "true",
-    "vt": "svt",
-    "mux": 8,
-    "ports": [
-      {
-        "address port name": "addr",
-        "address port polarity": "active high",
-        "clock port name": "clk",
-        "clock port polarity": "active high",
-        "write enable port name": "we",
-        "write enable port polarity": "active high",
-        "output port name": "dout",
-        "output port polarity": "active high",
-        "input port name": "din",
-        "input port polarity": "active high",
-        "mask port name": "wmask",
-        "mask granularity": 8,
         "mask port polarity": "active high"
       }
     ]

--- a/hammer/technology/sky130/sram-cache.json
+++ b/hammer/technology/sky130/sram-cache.json
@@ -1,34 +1,6 @@
 [
   {
     "type": "sram",
-    "name": "sram22_4096x8m8w8",
-    "source": "sram22",
-    "depth": "4096",
-    "width": 8,
-    "family": "1rw",
-    "mask": "true",
-    "vt": "svt",
-    "mux": 8,
-    "ports": [
-      {
-        "address port name": "addr",
-        "address port polarity": "active high",
-        "clock port name": "clk",
-        "clock port polarity": "active high",
-        "write enable port name": "we",
-        "write enable port polarity": "active high",
-        "output port name": "dout",
-        "output port polarity": "active high",
-        "input port name": "din",
-        "input port polarity": "active high",
-        "mask port name": "wmask",
-        "mask granularity": 8,
-        "mask port polarity": "active high"
-      }
-    ]
-  },
-  {
-    "type": "sram",
     "name": "sram22_512x32m4w32",
     "source": "sram22",
     "depth": "512",
@@ -163,34 +135,6 @@
         "input port polarity": "active high",
         "mask port name": "wmask",
         "mask granularity": 24,
-        "mask port polarity": "active high"
-      }
-    ]
-  },
-  {
-    "type": "sram",
-    "name": "sram22_4096x32m8w8",
-    "source": "sram22",
-    "depth": "4096",
-    "width": 32,
-    "family": "1rw",
-    "mask": "true",
-    "vt": "svt",
-    "mux": 8,
-    "ports": [
-      {
-        "address port name": "addr",
-        "address port polarity": "active high",
-        "clock port name": "clk",
-        "clock port polarity": "active high",
-        "write enable port name": "we",
-        "write enable port polarity": "active high",
-        "output port name": "dout",
-        "output port polarity": "active high",
-        "input port name": "din",
-        "input port polarity": "active high",
-        "mask port name": "wmask",
-        "mask granularity": 8,
         "mask port polarity": "active high"
       }
     ]


### PR DESCRIPTION
Removed SRAMs from sram-cache.json that do not have LEFs as they cause errors during PAR.

<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] Change to core Hammer
- [x] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
