### PR TITLE
minor: make lib_corner optional with default None

### DIFF
--- a/hammer/tech/__init__.py
+++ b/hammer/tech/__init__.py
@@ -59,7 +59,7 @@ TLUPlusMapFile = str
 class SpiceModelFile(BaseModel):
     # Struct that holds information about Spice model files.
     path: str
-    lib_corner: str
+    lib_corner: Optional[str] = None
 
     def to_setting(self) -> dict:
         output = {'path': str(self.path)}


### PR DESCRIPTION
The surrounding accounts for a null `lib_corner`, but the pydantic type forces it to be (unnecessarily) non-null.
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [x] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
