### PR TITLE
Relocate CPF Read + Power Strap Issues

### DIFF
--- a/hammer/config/defaults.yml
+++ b/hammer/config/defaults.yml
@@ -565,6 +565,8 @@ par:
   # Used by power straps and floorplanning
   # type: Decimal
 
+  power_to_route_blockage_ratio: 1.1 # By default, set the power halo + blockage spacing to 1.1x in every dimension relative to route blockage.
+
   blockage_spacing_top_layer: null # Top metal layer that is pulled back around blocks and hardmacros
   # Used by floorplanning.
   # Overridden by individual placement constraints on top_layer.

--- a/hammer/config/defaults_types.yml
+++ b/hammer/config/defaults_types.yml
@@ -280,6 +280,9 @@ par:
   # Spacing around blocks and hardmacros in microns
   blockage_spacing: float
 
+  # Ratio between the power blockage + place halo relative to route blockage. Route blockage should be smaller. 
+  power_to_route_blockage_ratio: float
+
   # Top metal layer that is pulled back around blocks and hardmacros
   # type: Optional[str]
   blockage_spacing_top_layer: Optional[str]

--- a/hammer/par/innovus/__init__.py
+++ b/hammer/par/innovus/__init__.py
@@ -486,7 +486,8 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
                     assign_arg = "-assign {{ {x} {y} }}".format(x=pin.location[0], y=pin.location[1])
 
                 layers_arg = ""
-                if set(pin.layers).intersection(set(power_pin_layers)):
+                
+                if set(pin.layers or []).intersection(set(power_pin_layers)):
                     self.logger.error("Signal pins will be generated on the same layer(s) as power pins. Double-check to see if intended.")
                 
                 if pin.layers is not None and len(pin.layers) > 0:
@@ -1075,7 +1076,10 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
                         output.append("create_route_halo -bottom_layer {b} -space {s} -top_layer {t} -inst {inst}".format(     
                             inst=new_path, b=bot_layer, t=current_top_layer, s=spacing))
                         
-                        place_push_out = round(spacing*1.2 , 1) # Push the place halo, and therefore PG blockage, further out from route halo so router is aware of straps before entering final routing.  
+                        if(self.get_setting("par.power_to_route_blockage_ratio") < 1):
+                            self.logger.warning("The power strap blockage region is smaller than the routing halo region for hard macros. Double-check if this is intended.")
+                            
+                        place_push_out = round(spacing*self.get_setting("par.power_to_route_blockage_ratio") , 1) # Push the place halo, and therefore PG blockage, further out from route halo so router is aware of straps before entering final routing.  
 
                         output.append("create_place_halo -insts {inst} -halo_deltas {{{s} {s} {s} {s}}} -snap_to_site".format(  
                             inst=new_path, s=place_push_out))

--- a/hammer/par/innovus/__init__.py
+++ b/hammer/par/innovus/__init__.py
@@ -1074,8 +1074,6 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
 
                         output.append("create_place_halo -insts {inst} -halo_deltas {{{s} {s} {s} {s}}} -snap_to_site".format(  
                             inst=new_path, s=place_push_out))
-                        #output.append("set pg_blockage_shape [lindex [get_computed_shapes -output polygon [get_db [get_db hinsts {inst}][get_db insts {inst}] .place_halo_polygon] SIZE {pg_pullback}] 0]".format(
-                        #    inst=new_path, pg_pullback=pg_pullback))
                         output.append("set pg_blockage_shape [get_db [get_db hinsts {inst}][get_db insts {inst}] .place_halo_polygon]".format(
                             inst=new_path))
                         output.append("create_route_blockage -pg_nets -layers {{{layers}}} -polygon $pg_blockage_shape".format(

--- a/hammer/par/innovus/__init__.py
+++ b/hammer/par/innovus/__init__.py
@@ -1066,14 +1066,16 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
                         current_top_layer = None
                     if current_top_layer is not None:
                         bot_layer = self.get_stackup().get_metal_by_index(1).name
-                        cover_layers = list(map(lambda m: m.name, self.get_stackup().get_metals_below_layer(current_top_layer)))
+                        cover_layers = list(map(lambda m: m.name, self.get_stackup().get_metals_incl_layer(current_top_layer)))
                         output.append("create_place_halo -insts {inst} -halo_deltas {{{s} {s} {s} {s}}} -snap_to_site".format(
                             inst=new_path, s=spacing))
                         output.append("create_route_halo -bottom_layer {b} -space {s} -top_layer {t} -inst {inst}".format(
                             inst=new_path, b=bot_layer, t=current_top_layer, s=spacing))
-                        output.append("create_route_blockage -pg_nets -inst {inst} -layers {{{layers}}} -cover".format(
+                        output.append("set place_halo_shape [get_db [get_db hinsts {inst}][get_db insts {inst}] .place_halo_polygon]".format(
+                            inst=new_path))
+                        output.append("create_route_blockage -pg_nets -layers {{{layers}}} -polygon $place_halo_shape".format(
                             inst=new_path, layers=" ".join(cover_layers)))
-
+                        
                 elif constraint.type == PlacementConstraintType.Obstruction:
                     obs_types = get_or_else(constraint.obs_types, [])  # type: List[ObstructionType]
                     assert '/' not in new_path, "'obstruction' placement constraints must be provided a path directly under the top level"

--- a/hammer/par/innovus/__init__.py
+++ b/hammer/par/innovus/__init__.py
@@ -422,6 +422,8 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
             self.logger.fatal("Cannot find top-level constraints to place pins")
             return False
 
+        power_pin_layers = self.get_setting("par.generate_power_straps_options.by_tracks.pin_layers")
+        
         const = cast(PlacementConstraint, topconst)
         assert isinstance(const.margins, Margins), "Margins must be defined for the top level"
         fp_llx = const.margins.left
@@ -484,6 +486,9 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
                     assign_arg = "-assign {{ {x} {y} }}".format(x=pin.location[0], y=pin.location[1])
 
                 layers_arg = ""
+                if set(pin.layers).intersection(set(power_pin_layers)):
+                    self.logger.error("Signal pins will be generated on the same layer(s) as power pins. Double-check to see if intended.")
+                
                 if pin.layers is not None and len(pin.layers) > 0:
                     layers_arg = "-layer {{ {} }}".format(" ".join(pin.layers))
 
@@ -1066,7 +1071,7 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
                         current_top_layer = None
                     if current_top_layer is not None:
                         bot_layer = self.get_stackup().get_metal_by_index(1).name
-                        cover_layers = list(map(lambda m: m.name, self.get_stackup().get_metals_incl_layer(current_top_layer)))
+                        cover_layers = list(map(lambda m: m.name, self.get_stackup().get_metals_below_layer(current_top_layer)))
                         output.append("create_route_halo -bottom_layer {b} -space {s} -top_layer {t} -inst {inst}".format(     
                             inst=new_path, b=bot_layer, t=current_top_layer, s=spacing))
                         
@@ -1076,8 +1081,7 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
                             inst=new_path, s=place_push_out))
                         output.append("set pg_blockage_shape [get_db [get_db hinsts {inst}][get_db insts {inst}] .place_halo_polygon]".format(
                             inst=new_path))
-                        output.append("create_route_blockage -pg_nets -layers {{{layers}}} -polygon $pg_blockage_shape".format(
-                            inst=new_path, layers=" ".join(cover_layers)))
+                        output.append("create_route_blockage -pg_nets -layers {{{layers}}} -polygon $pg_blockage_shape".format(layers=" ".join(cover_layers)))
                         
                 elif constraint.type == PlacementConstraintType.Obstruction:
                     obs_types = get_or_else(constraint.obs_types, [])  # type: List[ObstructionType]

--- a/hammer/par/innovus/__init__.py
+++ b/hammer/par/innovus/__init__.py
@@ -1071,8 +1071,9 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
                             inst=new_path, s=spacing))
                         output.append("create_route_halo -bottom_layer {b} -space {s} -top_layer {t} -inst {inst}".format(
                             inst=new_path, b=bot_layer, t=current_top_layer, s=spacing))
-                        output.append("set place_halo_shape [get_db [get_db hinsts {inst}][get_db insts {inst}] .place_halo_polygon]".format(
-                            inst=new_path))
+                        halo_pullback = -1*round(spacing*0.1 , 1)
+                        output.append("set place_halo_shape [get_computed_shapes [get_db [get_db hinsts {inst}][get_db insts {inst}] .place_halo_polygon] SIZE {halo_pullback}]".format(
+                            inst=new_path, halo_pullback=halo_pullback))
                         output.append("create_route_blockage -pg_nets -layers {{{layers}}} -polygon $place_halo_shape".format(
                             inst=new_path, layers=" ".join(cover_layers)))
                         

--- a/hammer/par/innovus/__init__.py
+++ b/hammer/par/innovus/__init__.py
@@ -1071,10 +1071,10 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
                             inst=new_path, s=spacing))
                         output.append("create_route_halo -bottom_layer {b} -space {s} -top_layer {t} -inst {inst}".format(
                             inst=new_path, b=bot_layer, t=current_top_layer, s=spacing))
-                        halo_pullback = -1*round(spacing*0.1 , 1)
-                        output.append("set place_halo_shape [get_computed_shapes [get_db [get_db hinsts {inst}][get_db insts {inst}] .place_halo_polygon] SIZE {halo_pullback}]".format(
-                            inst=new_path, halo_pullback=halo_pullback))
-                        output.append("create_route_blockage -pg_nets -layers {{{layers}}} -polygon $place_halo_shape".format(
+                        pg_pullback = -1*round(spacing*0.15 , 1)
+                        output.append("set pg_blockage_shape [get_computed_shapes [get_db [get_db hinsts {inst}][get_db insts {inst}] .place_halo_polygon] SIZE {pg_pullback}]".format(
+                            inst=new_path, pg_pullback=pg_pullback))
+                        output.append("create_route_blockage -pg_nets -layers {{{layers}}} -polygon $pg_blockage_shape".format(
                             inst=new_path, layers=" ".join(cover_layers)))
                         
                 elif constraint.type == PlacementConstraintType.Obstruction:

--- a/hammer/par/innovus/__init__.py
+++ b/hammer/par/innovus/__init__.py
@@ -1067,13 +1067,17 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
                     if current_top_layer is not None:
                         bot_layer = self.get_stackup().get_metal_by_index(1).name
                         cover_layers = list(map(lambda m: m.name, self.get_stackup().get_metals_incl_layer(current_top_layer)))
-                        output.append("create_place_halo -insts {inst} -halo_deltas {{{s} {s} {s} {s}}} -snap_to_site".format(
-                            inst=new_path, s=spacing))
-                        output.append("create_route_halo -bottom_layer {b} -space {s} -top_layer {t} -inst {inst}".format(
+                        output.append("create_route_halo -bottom_layer {b} -space {s} -top_layer {t} -inst {inst}".format(     
                             inst=new_path, b=bot_layer, t=current_top_layer, s=spacing))
-                        pg_pullback = -1*round(spacing*0.15 , 1)
-                        output.append("set pg_blockage_shape [lindex [get_computed_shapes -output polygon [get_db [get_db hinsts {inst}][get_db insts {inst}] .place_halo_polygon] SIZE {pg_pullback}] 0]".format(
-                            inst=new_path, pg_pullback=pg_pullback))
+                        
+                        place_push_out = round(spacing*1.2 , 1) # Push the place halo, and therefore PG blockage, further out from route halo so router is aware of straps before entering final routing.  
+
+                        output.append("create_place_halo -insts {inst} -halo_deltas {{{s} {s} {s} {s}}} -snap_to_site".format(  
+                            inst=new_path, s=place_push_out))
+                        #output.append("set pg_blockage_shape [lindex [get_computed_shapes -output polygon [get_db [get_db hinsts {inst}][get_db insts {inst}] .place_halo_polygon] SIZE {pg_pullback}] 0]".format(
+                        #    inst=new_path, pg_pullback=pg_pullback))
+                        output.append("set pg_blockage_shape [get_db [get_db hinsts {inst}][get_db insts {inst}] .place_halo_polygon]".format(
+                            inst=new_path))
                         output.append("create_route_blockage -pg_nets -layers {{{layers}}} -polygon $pg_blockage_shape".format(
                             inst=new_path, layers=" ".join(cover_layers)))
                         

--- a/hammer/par/innovus/__init__.py
+++ b/hammer/par/innovus/__init__.py
@@ -1072,7 +1072,7 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
                         output.append("create_route_halo -bottom_layer {b} -space {s} -top_layer {t} -inst {inst}".format(
                             inst=new_path, b=bot_layer, t=current_top_layer, s=spacing))
                         pg_pullback = -1*round(spacing*0.15 , 1)
-                        output.append("set pg_blockage_shape [get_computed_shapes [get_db [get_db hinsts {inst}][get_db insts {inst}] .place_halo_polygon] SIZE {pg_pullback}]".format(
+                        output.append("set pg_blockage_shape [lindex [get_computed_shapes -output polygon [get_db [get_db hinsts {inst}][get_db insts {inst}] .place_halo_polygon] SIZE {pg_pullback}] 0]".format(
                             inst=new_path, pg_pullback=pg_pullback))
                         output.append("create_route_blockage -pg_nets -layers {{{layers}}} -polygon $pg_blockage_shape".format(
                             inst=new_path, layers=" ".join(cover_layers)))

--- a/hammer/par/innovus/__init__.py
+++ b/hammer/par/innovus/__init__.py
@@ -309,10 +309,6 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
         # Run init_design to validate data and start the Cadence place-and-route workflow.
         verbose_append("init_design")
 
-        # Setup power settings from cpf/upf
-        for l in self.generate_power_spec_commands():
-            verbose_append(l)
-
         # Set the top and bottom global/detail routing layers.
         # This must happen after the tech LEF is loaded
         layers = self.get_setting("vlsi.technology.routing_layers")
@@ -342,6 +338,11 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
         # (after ILMs are placed)
         if self.hierarchical_mode.is_nonleaf_hierarchical():
             self.verbose_append("flatten_ilm")
+
+        # Setup power settings from cpf/upf
+        for l in self.generate_power_spec_commands():
+            self.verbose_append(l)
+
         for l in self.generate_dont_use_commands():
             self.append(l)
         if self.hierarchical_mode.is_nonleaf_hierarchical():

--- a/hammer/tech/stackup.py
+++ b/hammer/tech/stackup.py
@@ -406,6 +406,22 @@ class Stackup(BaseModel):
         except StopIteration:
             raise ValueError("Metal named %s is not defined in stackup %s" % (name, self.name))
 
+    def get_metals_incl_layer(self, name: str) -> List[Metal]:
+        """
+        Get all the metals including the specified metal layer.
+
+        :param index: Index of the metal layer
+        :return: A list of metal layer objects
+        """
+        try:
+            index = next(m.index for m in self.metals if m.name == name)
+            if index > 1:
+                return list(filter(lambda m: m.index in range(1, index+1), self.metals))
+            else:
+                raise ValueError("There are no metals below layer %s in stackup %s" % (name, self.name))
+        except StopIteration:
+            raise ValueError("Metal named %s is not defined in stackup %s" % (name, self.name))
+
     def get_metal_by_index(self, index: int) -> Metal:
         """
         Get a given metal layer by index.

--- a/hammer/tech/stackup.py
+++ b/hammer/tech/stackup.py
@@ -415,10 +415,6 @@ class Stackup(BaseModel):
         """
         try:
             index = next(m.index for m in self.metals if m.name == name)
-            if index > 1:
-                return list(filter(lambda m: m.index in range(1, index+1), self.metals))
-            else:
-                raise ValueError("There are no metals below layer %s in stackup %s" % (name, self.name))
         except StopIteration:
             raise ValueError("Metal named %s is not defined in stackup %s" % (name, self.name))
 

--- a/hammer/tech/stackup.py
+++ b/hammer/tech/stackup.py
@@ -415,6 +415,7 @@ class Stackup(BaseModel):
         """
         try:
             index = next(m.index for m in self.metals if m.name == name)
+            return list(filter(lambda m: m.index in range(1, index+1), self.metals))
         except StopIteration:
             raise ValueError("Metal named %s is not defined in stackup %s" % (name, self.name))
 


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**
- CPF intent can only be read when after ILM flattening. It is not possible to flatten ILMs before floorplanning. Hence, move the CPF read to later in the flow. 
-  Power straps continue to interact with routing within the halos. Proposed solution is like so: 1) Routing halo generation remains the same. Placement halo is slightly increased in size. A power routing blockage is then created in same shape as the placement halo. This allows router to avoid power straps in a non-routing-halo region, before subsequently entering the halo region (this seems to work better). Also, do this up to the top layer instead of layer-1.

<!-- choose one -->
**Type of change**:
- [X ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] Change to core Hammer
- [X ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [X ] Did you set `master` as the base branch?
- [X ] Did you state the type-of-change/impact?
- [ X] Did you delete any extraneous prints/debugging code?
- [ X] (If applicable) Did you add documentation for the feature?
- [ X] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ X] (If applicable) Did you add a unit test demonstrating the PR?
- [ X] (If applicable) Did you run this through the e2e integration tests?
- [ X] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
