### PR TITLE
Simultaneous setup/hold setting fix

### DIFF
--- a/hammer/par/innovus/__init__.py
+++ b/hammer/par/innovus/__init__.py
@@ -928,10 +928,6 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
         return True
 
     def write_design(self) -> bool:
-        # Because implementation is done, enable report_timing -early/late and SDF writing
-        # without recalculating timing graph for each analysis view
-        self.append("set_db timing_enable_simultaneous_setup_hold_mode true")
-
         # Save the Innovus design.
         self.verbose_append("write_db {lib_name} -def -verilog".format(
             lib_name=self.output_innovus_lib_name
@@ -1026,6 +1022,11 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
         self.output.clear()
         assert super().do_pre_steps(self.first_step)
         self.append("read_db latest")
+        if self.ran_write_design:
+            # Because implementation is done, enable report_timing -early/late and SDF writing
+            # without recalculating timing graph for each analysis view
+            self.append("set_db timing_enable_simultaneous_setup_hold_mode true")
+
         self.write_contents_to_path("\n".join(self.output), self.open_chip_tcl)
 
         with open(self.open_chip_script, "w") as f:


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
Previously this was done before final DB was written, causing hierarchical flow to fail. Now only gets set in open_chip script if final db was run.

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [X] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] Change to core Hammer
- [X] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [X] Did you set `master` as the base branch?
- [X] Did you state the type-of-change/impact?
- [X] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
