### PR TITLE
Small SDC fixes

### DIFF
--- a/hammer/vlsi/hammer_vlsi_impl.py
+++ b/hammer/vlsi/hammer_vlsi_impl.py
@@ -2229,7 +2229,7 @@ class HasSDCSupport(HammerTool):
 
         # Also specify loads for specific pins.
         for load in self.get_output_load_constraints():
-            output.append("set_load {load} [get_port {name}]".format(
+            output.append("set_load {load} [get_ports {name}]".format(
                 load=load.load.value_in_units(cap_unit),
                 name=load.name
             ))
@@ -2237,7 +2237,7 @@ class HasSDCSupport(HammerTool):
         # Also specify delays for specific pins.
         for delay in self.get_delay_constraints():
             minmax = {None: "", "setup": "-max", "hold": "-min"}
-            output.append("set_{direction}_delay {delay} -clock {clock} {minmax} [get_port {name}]".format(
+            output.append("set_{direction}_delay {delay} -clock {clock} {minmax} [get_ports {name}] -add_delay".format(
                 delay=delay.delay.value_in_units(self.get_time_unit().value_prefix + self.get_time_unit().unit),
                 clock=delay.clock,
                 direction=delay.direction,


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
`get_ports` is the proper SDC command
`-add_delay` in `set_min/max_delay` allows you to constrain the same path against multiple clocks. Otherwise, second one overrides all previous declarations.

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [X] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [X] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [X] Did you set `master` as the base branch?
- [X] Did you state the type-of-change/impact?
- [X] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
