### PR TITLE
Hier constraints from different files

### DIFF
--- a/doc/Hammer-Use/Hierarchical.rst
+++ b/doc/Hammer-Use/Hierarchical.rst
@@ -35,28 +35,14 @@ The hierarchal flow is controlled in the ``vlsi.inputs.hierarchal`` namespace. T
 Note how the configuration specific to each module in ``vlsi.inputs.hierarchical.constraints`` appears like they would in a flat flow. This means you can apply meta directives to them as normal, as long as the references are in the same parent dictionary (i.e., key = module name).
 If you have constraints for the same module in multiple files, you can use ``vlsi.inputs.hierarchical.constraints_meta: append`` and the constraints will be combined properly.
 
-There is legacy support for configurations where each item in the constraints is a list - in this case, meta actions are not supported and the entire project configuration must be specified in a single file.
+.. note::
+    In a bottom-up hierarchical flow, submodule instances must have ``type: hardmacro`` in ``vlsi.inputs.placement_constraints`` because they are hardened from below.
 
-Placement constraints for each module, however, are not specified here. Instead, they should be specified in ``vlsi.inputs.hierarchical.manual_placement_constraints``. The parameters such as ``x``, ``y``, ``width``, ``height``, etc. are omitted from each constraint for clarity. In the bottom-up hierarchal flow, instances of submodules are of ``type: hardmacro`` because they are hardened from below.
+Special considerations for legacy support:
 
-.. code-block:: yaml
+* If each module's ``constraints`` is a list of dicts with a single key/value pair, meta actions are not supported and the entire project configuration must be specified in a single file.
 
-    vlsi.inputs.hierarchical:
-      manual_placement_constraints_meta: append
-      manual_placement_constraints:
-      - ChipTop:
-        - path: "ChipTop"
-          type: toplevel
-        - path: "ChipTop/path/to/instance/of/ModuleA"
-          type: hardmacro
-      - ModuleA:
-        - path: "ModuleA"
-          type: toplevel
-        - path: "ModuleA/path/to/instance/of/ModuleAA"
-          type: hardmacro
-      - ModuleAA:
-        - path: "moduleAA"
-          type: toplevel
+* If placement constraints are specified with ``vlsi.inputs.hierarchical.manual_placement_constraints``, all of a given module's placement constraints must be specified in a single file.
 
 Flow Management and Actions
 ---------------------------
@@ -96,7 +82,7 @@ In a bottom-up hierarchical flow, is is important to remember that submodules do
 Special Notes & Limitations
 ---------------------------
 
-#. Hammer IR keys specified at the root level (i.e. outside of ``vlsi.inputs.hierarchical.constraints``) do not override the corresponding submodule constraints. However, if you add a Hammer IR file using ``-p`` on the command line (after the file containing ``vlsi.inputs.hierarchical.constraints``), those keys are global and override submodule constraints unless a meta action is specified. To avoid confusion, it is recommended to specify all constraints module-by-module with ``vlsi.inputs.hierarchical.constraints``.
+#. Hammer IR keys specified at the root level (i.e. outside of ``vlsi.inputs.hierarchical.constraints``) are overridden by the corresponding submodule constraints. Generally, to avoid confusion, it is recommended to specify all constraints module-by-module with ``vlsi.inputs.hierarchical.constraints``.
 
 #. Most Hammer APIs are not yet intelligent enough to constrain across hierarchical boundaries. For example:
 

--- a/doc/Hammer-Use/Hierarchical.rst
+++ b/doc/Hammer-Use/Hierarchical.rst
@@ -11,7 +11,7 @@ Hierarchical Hammer Config
 The hierarchal flow is controlled in the ``vlsi.inputs.hierarchal`` namespace. To specify hierarchical mode, you must specify the following keys. In this example, we have our top module set as ``ChipTop``, with a submodule ``ModuleA`` and another submdule ``ModuleAA`` below that (these are names of Verilog modules).
 
 .. code-block:: yaml
-    
+
     vlsi.inputs.hierarchical:
       mode: hierarchical
       top_module: ChipTop
@@ -23,16 +23,19 @@ The hierarchal flow is controlled in the ``vlsi.inputs.hierarchal`` namespace. T
         - ModuleAA
       constraints:
       - ChipTop:
-        - vlsi.core...
-        - vlsi.inputs...
+          vlsi.core...
+          vlsi.inputs...
       - ModuleA:
-        - vlsi.core...
-        - vlsi.inputs...
+          vlsi.core...
+          vlsi.inputs...
       - ModuleAA:
-        - vlsi.core...
-        - vlsi.inputs...
+          vlsi.core...
+          vlsi.inputs...
 
-Note how the configuration specific to each module in ``vlsi.inputs.hierarchical.constraints`` are list items, whereas in a flat flow, they would be at the root level.
+Note how the configuration specific to each module in ``vlsi.inputs.hierarchical.constraints`` appears like they would in a flat flow. This means you can apply meta directives to them as normal, as long as the references are in the same parent dictionary (i.e., key = module name).
+If you have constraints for the same module in multiple files, you can use ``vlsi.inputs.hierarchical.constraints_meta: append`` and the constraints will be combined properly.
+
+There is legacy support for configurations where each item in the constraints is a list - in this case, meta actions are not supported and the entire project configuration must be specified in a single file.
 
 Placement constraints for each module, however, are not specified here. Instead, they should be specified in ``vlsi.inputs.hierarchical.manual_placement_constraints``. The parameters such as ``x``, ``y``, ``width``, ``height``, etc. are omitted from each constraint for clarity. In the bottom-up hierarchal flow, instances of submodules are of ``type: hardmacro`` because they are hardened from below.
 
@@ -58,7 +61,7 @@ Placement constraints for each module, however, are not specified here. Instead,
 Flow Management and Actions
 ---------------------------
 
-Based on the structure in ``vlsi.inputs.hierarchical.manual_modules``, Hammer constructs a hierarchical flow graph of dependencies. In this particular example, synthesis and place-and-route of ``ModuleAA`` will happen first. Synthesis of ``ModuleA`` will then depend on the place-and-route output of ``ModuleAA``, and so forth. 
+Based on the structure in ``vlsi.inputs.hierarchical.manual_modules``, Hammer constructs a hierarchical flow graph of dependencies. In this particular example, synthesis and place-and-route of ``ModuleAA`` will happen first. Synthesis of ``ModuleA`` will then depend on the place-and-route output of ``ModuleAA``, and so forth.
 
 These are enumerated in the auto-generated Makefile, ``hammer.d``, which is placed in the directory pointed to by the ``--obj_dir`` command line flag when the ``buildfile`` action is run. This action must be run BEFORE executing your flow. If you adjust the hierarchy, you must re-run this action.
 
@@ -93,15 +96,9 @@ In a bottom-up hierarchical flow, is is important to remember that submodules do
 Special Notes & Limitations
 ---------------------------
 
-#. Hammer IR keys propagate up through the hierarchical tree. For example, if ``vlsi.inputs.clocks`` was specified in the constraints for ``ModuleAA`` but not for ``ModuleA``, ``ModuleA`` will inherit ``ModuleAA``'s constraints. Take special care of where your constraints come from, especially for a parent module with more than one submodule. To avoid confusion, it is recommended to specify the same set of keys for every module.
+#. Hammer IR keys propagate up through the hierarchical tree when using the auto-generated Makefile. For example, if ``vlsi.inputs.clocks`` was specified in the constraints for ``ModuleAA`` but not for ``ModuleA``, ``ModuleA`` will inherit ``ModuleAA``'s constraints. Take special care of where your constraints come from, especially for a parent module with more than one submodule. To avoid confusion, it is recommended to specify the same set of keys for every module.
 
 #. Hammer IR keys specified at the root level (i.e. outside of ``vlsi.inputs.hierarchical.constraints``) do not override the corresponding submodule constraints. However, if you add a Hammer IR file using ``-p`` on the command line (after the file containing ``vlsi.inputs.hierarchical.constraints``), those keys are global and override submodule constraints unless a meta action is specified. To avoid confusion, it is recommended to specify all constraints with ``vlsi.inputs.hierarchical.constraints``.
-
-#. Due to the structure of ``vlsi.inputs.hierarchical.constraints`` as a list structure, currently, there are the following limitations:
-
-    * You must include all of the constraints in a single file. The config parser is unable to combine constraints from differnt files because most meta actions do not work on list items (advanced users will need to use ``deepsubst``). This will make it harder for collaboration, and unfortunately, changes to module constraints at a higher level of hierarchy after submodules are hardened will trigger the Make dependencies, so you will need to modify the generated Makefile or use redo-targets.
-
-    * Other issues have been observed, such as the bump API failing (see `this issue <https://github.com/ucb-bar/hammer/issues/401>`_ at the top module level. This is caused by similar mechanisms as above. The workaround is to ensure that bumps are specified at the root level for only the top module and the bumps step is removed from submodule par actions.
 
 #. Most Hammer APIs are not yet intelligent enough to constrain across hierarchical boundaries. For example:
 

--- a/doc/Hammer-Use/Hierarchical.rst
+++ b/doc/Hammer-Use/Hierarchical.rst
@@ -96,9 +96,7 @@ In a bottom-up hierarchical flow, is is important to remember that submodules do
 Special Notes & Limitations
 ---------------------------
 
-#. Hammer IR keys propagate up through the hierarchical tree when using the auto-generated Makefile. For example, if ``vlsi.inputs.clocks`` was specified in the constraints for ``ModuleAA`` but not for ``ModuleA``, ``ModuleA`` will inherit ``ModuleAA``'s constraints. Take special care of where your constraints come from, especially for a parent module with more than one submodule. To avoid confusion, it is recommended to specify the same set of keys for every module.
-
-#. Hammer IR keys specified at the root level (i.e. outside of ``vlsi.inputs.hierarchical.constraints``) do not override the corresponding submodule constraints. However, if you add a Hammer IR file using ``-p`` on the command line (after the file containing ``vlsi.inputs.hierarchical.constraints``), those keys are global and override submodule constraints unless a meta action is specified. To avoid confusion, it is recommended to specify all constraints with ``vlsi.inputs.hierarchical.constraints``.
+#. Hammer IR keys specified at the root level (i.e. outside of ``vlsi.inputs.hierarchical.constraints``) do not override the corresponding submodule constraints. However, if you add a Hammer IR file using ``-p`` on the command line (after the file containing ``vlsi.inputs.hierarchical.constraints``), those keys are global and override submodule constraints unless a meta action is specified. To avoid confusion, it is recommended to specify all constraints module-by-module with ``vlsi.inputs.hierarchical.constraints``.
 
 #. Most Hammer APIs are not yet intelligent enough to constrain across hierarchical boundaries. For example:
 

--- a/e2e/configs-design/pass/mock_hier.yml
+++ b/e2e/configs-design/pass/mock_hier.yml
@@ -28,6 +28,10 @@ vlsi.inputs.hierarchical:
     - SubModC: []
     - SubModD: []
     - SubModE: []
+  constraints:
+    - SubModA:
+        - vlsi.inputs.power_spec_type: manual
+        - vlsi.inputs.power_spec_contents: fake_upf_command
 
 vlsi.core.synthesis_tool: "hammer.synthesis.mocksynth"
 synthesis.mocksynth.temp_folder: "obj_dir"

--- a/e2e/configs-design/pass/mock_hier.yml
+++ b/e2e/configs-design/pass/mock_hier.yml
@@ -29,9 +29,10 @@ vlsi.inputs.hierarchical:
     - SubModD: []
     - SubModE: []
   constraints:
-    - SubModA:
-        - vlsi.inputs.power_spec_type: manual
-        - vlsi.inputs.power_spec_contents: fake_upf_command
+    - SubModC:
+        vlsi.inputs.power_spec_type: manual
+        vlsi.inputs.power_spec_contents: fake_command
+        par.generate_power_straps_options.by_tracks.strap_layers: [m3, m4, m5]
 
 vlsi.core.synthesis_tool: "hammer.synthesis.mocksynth"
 synthesis.mocksynth.temp_folder: "obj_dir"

--- a/e2e/configs-design/pass/mock_hier_addl.yml
+++ b/e2e/configs-design/pass/mock_hier_addl.yml
@@ -1,18 +1,6 @@
 vlsi.inputs.hierarchical.constraints_meta: append
 vlsi.inputs.hierarchical.constraints:
-  - SubModB:
-      - vlsi.inputs.power_spec_type: upf
-vlsi.inputs.hierarchical.manual_placement_constraints_meta: append
-vlsi.inputs.hierarchical.manual_placement_constraints:
-  - SubModB:
-      - path: SubModB
-        type: toplevel
-        x: 0
-        y: 0
-        width: 100
-        height: 100
-        margins:
-          left: 0
-          right: 0
-          top: 0
-          bottom: 0
+  - SubModC:
+      vlsi.inputs.power_spec_type: upf
+      par.generate_power_straps_options.by_tracks.strap_layers: [m6]
+      par.generate_power_straps_options.by_tracks.strap_layers_meta: append

--- a/e2e/configs-design/pass/mock_hier_addl.yml
+++ b/e2e/configs-design/pass/mock_hier_addl.yml
@@ -1,0 +1,18 @@
+vlsi.inputs.hierarchical.constraints_meta: append
+vlsi.inputs.hierarchical.constraints:
+  - SubModB:
+      - vlsi.inputs.power_spec_type: upf
+vlsi.inputs.hierarchical.manual_placement_constraints_meta: append
+vlsi.inputs.hierarchical.manual_placement_constraints:
+  - SubModB:
+      - path: SubModB
+        type: toplevel
+        x: 0
+        y: 0
+        width: 100
+        height: 100
+        margins:
+          left: 0
+          right: 0
+          top: 0
+          bottom: 0

--- a/e2e/configs-design/pass/mock_hier_legacy.yml
+++ b/e2e/configs-design/pass/mock_hier_legacy.yml
@@ -21,33 +21,26 @@ vlsi.inputs.hierarchical:
         - SubModD
     - SubModB:
         - SubModE
-  constraints:
-    - ChipTop:
-        vlsi.inputs.placement_constraints:
-        - path: ChipTop
-          type: toplevel
-          x: 0
-          y: 0
-          width: 1000
-          height: 1000
-          margins:
-            left: 0
-            right: 0
-            top: 0
-            bottom: 0
+  manual_placement_constraints:
+    - ChipTop: []
+    - SubModA: []
+    - SubModB: []
     - SubModC:
-        vlsi.inputs.placement_constraints:
-        - path: SubModC
-          type: toplevel
-          x: 0
-          y: 0
-          width: 100
-          height: 100
-          margins:
-            left: 0
-            right: 0
-            top: 0
-            bottom: 0
+      - path: SubModC
+        type: toplevel
+        x: 0
+        y: 0
+        width: 100
+        height: 100
+        margins:
+          left: 0
+          right: 0
+          top: 0
+          bottom: 0
+    - SubModD: []
+    - SubModE: []
+  constraints:
+    - SubModC:
         vlsi.inputs.power_spec_type: manual
         vlsi.inputs.power_spec_contents: fake_command
         par.generate_power_straps_options.by_tracks.strap_layers: [m3, m4, m5]

--- a/hammer/config/config_src.py
+++ b/hammer/config/config_src.py
@@ -790,9 +790,9 @@ class HammerDatabase:
         return [self._runtime]
 
     @staticmethod
-    def internal_keys() -> Set[str]:
+    def internal_keys() -> List[str]:
         """Internal keys that shouldn't show up in any final config."""
-        return {_CONFIG_PATH_KEY, _NEXT_FREE_INDEX_KEY}
+        return [_CONFIG_PATH_KEY, _NEXT_FREE_INDEX_KEY]
 
     def get_config(self) -> dict:
         """

--- a/hammer/config/defaults.yml
+++ b/hammer/config/defaults.yml
@@ -60,13 +60,13 @@ vlsi.technology:
   bump_block_cut_layer: null # Top cut/via layer for blockage under bumps. (Optional[str])
   # Only used if using vlsi.inputs.bumps
   # TODO: remove this after stackup supports vias ucb-bar/hammer#354
-  
+
   tap_cell_interval: 10.0 # Spacing between columns of tap cells (float)
   # Must be overridden by technology plugin defaults or else you will have DRC/latch-up errors.
 
   tap_cell_offset: 0.0 # Offset of the first column of tape cells from the edge of the floorplan (float)
   # Should be overridden by technology plugin defaults.
-  
+
   routing_layers: null # If specified, set/override the [bottom, top] layers used for routing. (Optional[Tuple[int, int]])
   # Both must match the index number (not name) of layers used in the stackup.
 
@@ -103,7 +103,7 @@ vlsi.technology:
 
   timing_lib_pref: "NLDM"
   # Select a timing lib preference, available options include:
-  # NLDM, ECSM, and CCS (lower or upper case acceptable). 
+  # NLDM, ECSM, and CCS (lower or upper case acceptable).
   # If no preference is specified, then the following preference order is followed:
   # NLDM -> ECSM -> CCS
 
@@ -145,7 +145,7 @@ vlsi.inputs:
     manual_modules: [] # Manual hierarchical definitions used only if hierarchical_definition_source is set to manual mode.
     # Should be a list along the lines of [{"module1": "module1_sub1", "module1_sub2", "module2": "module2_sub"}].
 
-    manual_placement_constraints: [] # Manual hierarchical placement constraints used only if hierarchical_definition_source is set to manual mode.
+    manual_placement_constraints: [] # (Deprecated) Manual hierarchical placement constraints used only if hierarchical_definition_source is set to manual mode.
     # Should be a list along the lines of [{"module1": <list of PlacementConstraint structs>}].
 
     constraints: [] # Manual hierarchical constraints. Overrides generic constraints on a per module basis.
@@ -212,7 +212,7 @@ vlsi.inputs:
   custom_sdc_constraints: [] # List of custom sdc constraints to use. (List[str])
   # These are appended after all other generated constraints (clock, pin, delay, load, etc.).
   # IMPORTANT: Since SDC is unitless, you must manually verify that your time & cap units match the tech library's units.
-  
+
   custom_sdc_files: [] # List of custom sdc files to append. (List[str])
   # These are appended after all other generated constraints and custom_sdc_constraints.
 
@@ -328,7 +328,7 @@ vlsi.inputs:
     # type: float
     pitch: 0.0
     global_x_offset: 0.0 # offset the bump map in the x-axis (float)
-    global_y_offset: 0.0 # offset the bump map in the y-axis (float)    
+    global_y_offset: 0.0 # offset the bump map in the y-axis (float)
     cell: "" # cell (str) - Name of the default bump cell
     assignments: [] # assignments - List of BumpAssignment structs. You must specify one of name or no_connect.
     # If both are specified the bump will be left unconnected
@@ -898,7 +898,7 @@ power.inputs:
   #       "write_profile" - profiles all power types on all categories for all the sub-hierarchies for a given design instance (*.fsdb)
   #       "profile" - run plot_profile + dump_profile
   #       "all" - generate all of the above report formats
-  
+
   # examples:
   #   report_configs: [{waveform_path: "/path/to/fsdb", module: "chiptop", levels:3, start_time: "0ns", end_time: "1ns", toggle_signal:"/ChipTop/clock", num_toggles:1, frame_count:1000, report_name: "my_fsdb_report"}]
   #   report_configs: [{waveform_path: "/path/to/fsdb", inst: "ChipTop/system/tile_prci_domain/tile_reset_domain_tile", interval_size: "1ns", output_formats: ["plot_profile"]}]

--- a/hammer/config/defaults_types.yml
+++ b/hammer/config/defaults_types.yml
@@ -58,7 +58,7 @@ vlsi.technology:
 
   # Offset of the first column of tape cells from the edge of the floorplan
   # type: float
-  tap_cell_offset: float 
+  tap_cell_offset: float
 
   # Set the [bottom, top] layer used for routing. (Optional[Tuple[int, int]])
   routing_layers: Optional[list[int]]
@@ -105,7 +105,7 @@ vlsi.inputs:
     manual_placement_constraints: list[dict[str, list]]
 
     # Manual hierarchical constraints. Overrides generic constraints on a per module basis.
-    constraints: list[dict[str, list]]
+    constraints: list[dict[str, Any]]
 
   # ILMs for hierarchical mode.
   ilms: list[dict[str, str]]
@@ -160,9 +160,9 @@ vlsi.inputs:
     y: int
     # pitch (float) - pitch of bumps in microns
     pitch: float
-    # global_x_offset (float) - offset the bump map in the x-axis 
+    # global_x_offset (float) - offset the bump map in the x-axis
     global_x_offset: float
-    # global_y_offset (float) - offset the bump map in the y-axis 
+    # global_y_offset (float) - offset the bump map in the y-axis
     global_y_offset: float
     # cell (str) - Name of the default bump cell
     cell: str
@@ -283,7 +283,7 @@ par:
   # Spacing around blocks and hardmacros in microns
   blockage_spacing: float
 
-  # Ratio between the power blockage + place halo relative to route blockage. Route blockage should be smaller. 
+  # Ratio between the power blockage + place halo relative to route blockage. Route blockage should be smaller.
   power_to_route_blockage_ratio: float
 
   # Top metal layer that is pulled back around blocks and hardmacros

--- a/hammer/par/innovus/__init__.py
+++ b/hammer/par/innovus/__init__.py
@@ -108,7 +108,7 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
 
     @property
     def output_gds_filename(self) -> str:
-        return os.path.join(self.run_dir, "{top}.gds".format(top=self.top_module))
+        return os.path.join(self.run_dir, "{top}.gds.gz".format(top=self.top_module))
 
     @property
     def output_netlist_filename(self) -> str:

--- a/hammer/vlsi/cli_driver.py
+++ b/hammer/vlsi/cli_driver.py
@@ -475,6 +475,7 @@ class CLIDriver:
             raise ValueError("Output-only config does not appear to be output only")
 
         output_full = deepdict(driver.project_config)
+        driver.remove_hierarchical_settings(output_full)
         output_full.update(deepdict(output))
         # Merged configs are always complete
         if "vlsi.builtins.is_complete" in output_full:

--- a/hammer/vlsi/cli_driver.py
+++ b/hammer/vlsi/cli_driver.py
@@ -456,32 +456,6 @@ class CLIDriver:
         return self.create_action("par", hooks if len(hooks) > 0 else None,
                                   pre_action_func, post_load_func, post_run_func)
 
-    @staticmethod
-    def get_full_config(driver: HammerDriver, output: dict) -> dict:
-        """
-        Get the full configuration by combining the project config from the
-        driver with the given output dict (i.e. it contains only
-        "synthesis.output.blah") that we want to combine with the project
-        config.
-        :param driver: HammerDriver that has the full project config.
-        :param output: Output dict containing specific settings we want to add
-                       to the full project config.
-        :return: Full project config combined with the output dict
-        """
-        if "vlsi.builtins.is_complete" in output:
-            if bool(output["vlsi.builtins.is_complete"]):
-                raise ValueError("Output-only config claims it is complete")
-        else:
-            raise ValueError("Output-only config does not appear to be output only")
-
-        output_full = deepdict(driver.project_config)
-        driver.remove_hierarchical_settings(output_full)
-        output_full.update(deepdict(output))
-        # Merged configs are always complete
-        if "vlsi.builtins.is_complete" in output_full:
-            del output_full["vlsi.builtins.is_complete"]
-        return output_full
-
     def create_drc_action(self, custom_hooks: List[HammerToolHookAction],
                           pre_action_func: Optional[Callable[[HammerDriver], None]] = None,
                           post_load_func: Optional[Callable[[HammerDriver], None]] = None,
@@ -598,13 +572,13 @@ class CLIDriver:
                 if not success:
                     driver.log.error("Synthesis tool did not succeed")
                     return None
+                post_run_func_checked(driver)
                 dump_config_to_json_file(os.path.join(driver.syn_tool.run_dir, "syn-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.syn_tool.run_dir, "syn-output-full.json"),
                                          self.get_full_config(driver, output))
                 if driver.dump_history:
                     dump_config_to_yaml_file(os.path.join(driver.syn_tool.run_dir, "syn-output-history.yml"),
                                             add_key_history(self.get_full_config(driver, output), key_history))
-                post_run_func_checked(driver)
             elif action_type == "par":
                 if not driver.load_par_tool(get_or_else(self.par_rundir, "")):
                     return None
@@ -618,13 +592,13 @@ class CLIDriver:
                 if not success:
                     driver.log.error("Place-and-route tool did not succeed")
                     return None
+                post_run_func_checked(driver)
                 dump_config_to_json_file(os.path.join(driver.par_tool.run_dir, "par-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.par_tool.run_dir, "par-output-full.json"),
                                          self.get_full_config(driver, output))
                 if driver.dump_history:
                     dump_config_to_yaml_file(os.path.join(driver.par_tool.run_dir, "par-output-history.yml"),
                                             add_key_history(self.get_full_config(driver, output), key_history))
-                post_run_func_checked(driver)
             elif action_type == "drc":
                 if not driver.load_drc_tool(get_or_else(self.drc_rundir, "")):
                     return None
@@ -638,13 +612,13 @@ class CLIDriver:
                 if not success:
                     driver.log.error("DRC tool did not succeed")
                     return None
+                post_run_func_checked(driver)
                 dump_config_to_json_file(os.path.join(driver.drc_tool.run_dir, "drc-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.drc_tool.run_dir, "drc-output-full.json"),
                                          self.get_full_config(driver, output))
                 if driver.dump_history:
                     dump_config_to_yaml_file(os.path.join(driver.drc_tool.run_dir, "drc-output-history.yml"),
                                             add_key_history(self.get_full_config(driver, output), key_history))
-                post_run_func_checked(driver)
             elif action_type == "lvs":
                 if not driver.load_lvs_tool(get_or_else(self.lvs_rundir, "")):
                     return None
@@ -658,13 +632,13 @@ class CLIDriver:
                 if not success:
                     driver.log.error("LVS tool did not succeed")
                     return None
+                post_run_func_checked(driver)
                 dump_config_to_json_file(os.path.join(driver.lvs_tool.run_dir, "lvs-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.lvs_tool.run_dir, "lvs-output-full.json"),
                                          self.get_full_config(driver, output))
                 if driver.dump_history:
                     dump_config_to_yaml_file(os.path.join(driver.lvs_tool.run_dir, "lvs-output-history.yml"),
                                             add_key_history(self.get_full_config(driver, output), key_history))
-                post_run_func_checked(driver)
             elif action_type == "sram_generator":
                 if not driver.load_sram_generator_tool(get_or_else(self.sram_generator_rundir, "")):
                     return None
@@ -692,13 +666,13 @@ class CLIDriver:
                 if not success:
                     driver.log.error("Sim tool did not succeed")
                     return None
+                post_run_func_checked(driver)
                 dump_config_to_json_file(os.path.join(driver.sim_tool.run_dir, "sim-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.sim_tool.run_dir, "sim-output-full.json"),
                                          self.get_full_config(driver, output))
                 if driver.dump_history:
                     dump_config_to_yaml_file(os.path.join(driver.sim_tool.run_dir, "sim-output-history.yml"),
                                             add_key_history(self.get_full_config(driver, output), key_history))
-                post_run_func_checked(driver)
             elif action_type == "power":
                 if not driver.load_power_tool(get_or_else(self.power_rundir, "")):
                     return None
@@ -712,13 +686,13 @@ class CLIDriver:
                 if not success:
                     driver.log.error("Power tool did not succeed")
                     return None
+                post_run_func_checked(driver)
                 dump_config_to_json_file(os.path.join(driver.power_tool.run_dir, "power-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.power_tool.run_dir, "power-output-full.json"),
                                          self.get_full_config(driver, output))
                 if driver.dump_history:
                     dump_config_to_yaml_file(os.path.join(driver.power_tool.run_dir, "power-output-history.yml"),
                                             add_key_history(self.get_full_config(driver, output), key_history))
-                post_run_func_checked(driver)
             elif action_type == "formal":
                 if not driver.load_formal_tool(get_or_else(self.formal_rundir, "")):
                     return None
@@ -732,13 +706,13 @@ class CLIDriver:
                 if not success:
                     driver.log.error("Formal tool did not succeed")
                     return None
+                post_run_func_checked(driver)
                 dump_config_to_json_file(os.path.join(driver.formal_tool.run_dir, "formal-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.formal_tool.run_dir, "formal-output-full.json"),
                                          self.get_full_config(driver, output))
                 if driver.dump_history:
                     dump_config_to_yaml_file(os.path.join(driver.formal_tool.run_dir, "formal-output-history.yml"),
                                             add_key_history(self.get_full_config(driver, output), key_history))
-                post_run_func_checked(driver)
             elif action_type == "timing":
                 if not driver.load_timing_tool(get_or_else(self.timing_rundir, "")):
                     return None
@@ -752,10 +726,10 @@ class CLIDriver:
                 if not success:
                     driver.log.error("Timing tool did not succeed")
                     return None
+                post_run_func_checked(driver)
                 dump_config_to_json_file(os.path.join(driver.timing_tool.run_dir, "timing-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.timing_tool.run_dir, "timing-output-full.json"),
                                          self.get_full_config(driver, output))
-                post_run_func_checked(driver)
             elif action_type == "pcb":
                 if not driver.load_pcb_tool(get_or_else(self.pcb_rundir, "")):
                     return None
@@ -769,13 +743,13 @@ class CLIDriver:
                 if not success:
                     driver.log.error("PCB deliverable tool did not succeed")
                     return None
+                post_run_func_checked(driver)
                 dump_config_to_json_file(os.path.join(driver.pcb_tool.run_dir, "pcb-output.json"), output)
                 dump_config_to_json_file(os.path.join(driver.pcb_tool.run_dir, "pcb-output-full.json"),
                                          self.get_full_config(driver, output))
                 if driver.dump_history:
                     dump_config_to_yaml_file(os.path.join(driver.pcb_tool.run_dir, "pcb-output-history.yml"),
                                             add_key_history(self.get_full_config(driver, output), key_history))
-                post_run_func_checked(driver)
             else:
                 raise ValueError("Invalid action_type = " + str(action_type))
             # TODO: detect errors
@@ -1264,6 +1238,31 @@ class CLIDriver:
         """Get the list of valid actions for the command-line driver."""
         return list(self.action_map().keys())
 
+    @staticmethod
+    def get_full_config(driver: HammerDriver, output: dict) -> dict:
+        """
+        Get the full configuration by combining the project config from the
+        driver with the given output dict (i.e. it contains only
+        "synthesis.output.blah") that we want to combine with the project
+        config.
+        :param driver: HammerDriver that has the full project config.
+        :param output: Output dict containing specific settings we want to add
+                       to the full project config.
+        :return: Full project config combined with the output dict
+        """
+        if "vlsi.builtins.is_complete" in output:
+            if bool(output["vlsi.builtins.is_complete"]):
+                raise ValueError("Output-only config claims it is complete")
+        else:
+            raise ValueError("Output-only config does not appear to be output only")
+
+        output_full = deepdict(driver.project_config)
+        output_full.update(deepdict(output))
+        # Merged configs are always complete
+        if "vlsi.builtins.is_complete" in output_full:
+            del output_full["vlsi.builtins.is_complete"]
+        return output_full
+
     def args_to_driver(self, args: dict,
                        default_options: Optional[HammerDriverOptions] = None) -> \
             Tuple[HammerDriver, List[str]]:
@@ -1425,6 +1424,8 @@ class CLIDriver:
                         module=module))  # TODO(edwardw): fix this ugly os.path.join; it doesn't belong here.
                     # TODO(edwardw): remove ugly hack to store stuff in parent context
                     base_project_config[0] = deeplist(driver.project_configs)
+                    print(base_project_config[0])
+                    print(config)
                     d.update_project_configs(deeplist(base_project_config[0]) + [config])
 
                 def par_pre_func(d: HammerDriver) -> None:
@@ -1484,7 +1485,7 @@ class CLIDriver:
                     with open(os.path.join(rundir, "module_config.json"), "w") as f:
                         new_output_json = json.dumps(config, cls=HammerJSONEncoder, indent=4)
                         f.write(new_output_json)
-
+                    # Restore the original project config to remove hierarchical settings.
                     d.update_project_configs(deeplist(base_project_config[0]))
 
                 def syn_post_run(d: HammerDriver) -> None:

--- a/hammer/vlsi/driver.py
+++ b/hammer/vlsi/driver.py
@@ -65,7 +65,7 @@ class HammerDriver:
         file_logger = HammerVLSIFileLogger(options.log_file)
         HammerVLSILogging.add_callback(file_logger.callback)
         self.log = HammerVLSILogging.context()  # type: HammerVLSILoggingContext
-        
+
         # Create a new hammer database.
         self.database = hammer_config.HammerDatabase()  # type: hammer_config.HammerDatabase
 
@@ -1716,22 +1716,21 @@ class HammerDriver:
             # Iterate over project configs to find which ones contain hierarchical constraints
             # For each file that does append its path to the special key in the extracted
             # hierarchical constraints section.
-            """
             hier_constraint_source = ""  # type: str
             for project_conf in self.project_configs:
                 if "vlsi.inputs.hierarchical.constraints" in project_conf:
-                    hier_constraint_source = project_conf[hammer_config._CONFIG_PATH_KEY]
+                    [config_path_key, _] = self.database.internal_keys()
+                    hier_constraint_source = project_conf[config_path_key]
                     pc = project_conf["vlsi.inputs.hierarchical.constraints"]  # type: List[Dict]
                     # Add CONFIG_PATH_KEY to actual project configs for each project config's hierarchical constraint
                     # keys then update project configs at the end
                     for md in pc:
                         md  # one entry dict with a list
                         for m in md.keys():
-                            if hammer_config._CONFIG_PATH_KEY in md[m][-1]:
+                            if config_path_key in md[m][-1]:
                                 pass
                             else:
-                                md[m].append({hammer_config._CONFIG_PATH_KEY: hier_constraint_source})
-            """
+                                md[m].append({config_path_key: hier_constraint_source})
             self.update_project_configs(self.project_configs)
             list_of_hier_constraints = self.database.get_setting(
                     "vlsi.inputs.hierarchical.constraints") # type: List[Dict]

--- a/hammer/vlsi/driver.py
+++ b/hammer/vlsi/driver.py
@@ -1742,14 +1742,11 @@ class HammerDriver:
                 # Check if the hierarchical constraints are a list of dicts or a dict
                 # list of dicts is for legacy compatibility. Meta directives don't work.
                 if isinstance(next(iter(list_of_hier_constraints[0].values())), list):
-                    print("list of dicts")
                     hier_constraints = reduce(add_dicts, list_of_hier_constraints, {})
                 else:
                     # run combine_configs per module to resolve meta directives
                     for module in combined_raw_placement_dict:
                         mod_configs = list(map(lambda x: x.get(module, {}), list_of_hier_constraints))
-                        print(module)
-                        print(mod_configs)
                         hier_constraints[module] = hammer_config.combine_configs(mod_configs)
         elif hier_source == "from_placement":
             raise NotImplementedError("Generation from placement not implemented yet")


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
It appears that #675 commented out #626, which was one step towards getting `vlsi.inputs.hierarchical.constraints` to support meta directives.

Now, module-level constraints can come from different files, as long as `vlsi.inputs.hierarchical.constraints_meta: append` is set. Each file can contain part of the constraints for a given module. This addresses most of #401 I believe.

Ran thru a quick e2e mock test:
```
hammer-vlsi -p configs-design/pass/mock_hier.yml -p configs-design/pass/mock_hier_addl.yml syn-SubModC
```
Reviewing `syn-SubModC/module_config.json` files shows the correct module-specific config and `syn-SubModC/syn-output-full.json` shows SubModC's specific `vlsi.inputs.hierchical.constraints` not making it through.

TODO:
- [x] Remove `vlsi.inputs.hierarchical.manual_placement_constraints`. This should be legacy and completely replaceable by using `vlsi.inputs.placement_constraints` inside the submodule's constraint dict.
- [x] Fix upward propagation of constraints. Essentially need to remove module-specific constraints from the global output config dict from every action.
- [ ] Investigate if/why bumps still buggy after these fixes @kevindna 

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->
Closes #401

<!-- choose one -->
**Type of change**:
- [X] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [X] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [X] Did you set `master` as the base branch?
- [X] Did you state the type-of-change/impact?
- [X] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [X] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
