### PR TITLE
Flowgraph fixes

### DIFF
--- a/doc/Hammer-Use/Flowgraphs.rst
+++ b/doc/Hammer-Use/Flowgraphs.rst
@@ -10,15 +10,15 @@ They can be imported via the ``hammer.flowgraph`` module.
 Construction
 ------------
 
-Flowgraphs are nothing more than a collection of ``Node`` instances linked together via a ``Graph`` instance.
+Flowgraphs are consist of a collection of ``Node`` instances linked together via a ``Graph`` instance.
 Each ``Node`` "pulls" from a directory to feed in inputs and "pushes" output files to another directory to be used by other nodes.
-``Node`` instances are roughly equivalent to a single call to the ``hammer-vlsi`` CLI, so they take in similar attributes:
+``Node`` instances are roughly equivalent to a single call to the ``hammer-vlsi`` CLI tool, so they take in similar attributes:
 
 * The action being called
 * The tool used to perform the action
 * The pull and push directories
 * Any *required* input/output files
-* Any *optional* input/output files
+* Any *optional* input/output files (the name of the *first* output file corresponds to the name of the JSON that the action emits)
 * A driver to run the node with; this enables backwards compatibility with :ref:`hooks <hooks>`.
 * Options to specify steps within an action; this enables backwards compatibility with :ref:`flow control <flow-control>`.
 
@@ -71,7 +71,7 @@ This list can be used to instantiate a ``Graph``:
 Using the Hammer CLI tool, separate actions are manually linked via an *auxiliary* action, such as ``syn-to-par``.
 By using a flowgraph, ``Graph`` instances by default *automatically* insert auxiliary actions.
 This means that actions no longer need to be specified in a flow; the necessary nodes are inserted by the flowgraph tool.
-This feature can be disabled by setting ``auto_auxiliary=False``.
+This feature can be disabled by setting ``auto_auxiliary`` to ``False`` in a ``Graph``.
 
 A ``Graph`` can be run by calling the ``run`` method and passing in a starting node.
 When running a flow, each ``Node`` keeps an internal status based on the status of the action being run:
@@ -82,7 +82,7 @@ When running a flow, each ``Node`` keeps an internal status based on the status 
 * ``INCOMPLETE``: The action ran into an error while being run.
 * ``INVALID``: The action's outputs have been invalidated (e.g. inputs or attributes have changed).
 
-The interactions between the statuses are described in the diagram:
+The interactions between the statuses are described in the following state diagram:
 
 .. mermaid::
 
@@ -155,3 +155,11 @@ Which would render like this:
         syn_to_par --> par
 
 Note that the separators have been changed to comply with Mermaid syntax.
+
+Caveats
+-------
+
+The flowgraph frontend has a number of caveats that prevent it from full parity with the current CLI tool:
+
+* If flows are constructed in a Python interactive session, then errors from the underlying tool do *not* propagate to the flowgraph and thus render the interactive session unusable.
+  This can be worked around by embedding the flow in a Python script and running it from the command line.

--- a/hammer/flowgraph/flowgraph.py
+++ b/hammer/flowgraph/flowgraph.py
@@ -10,21 +10,18 @@
 
 import json
 import os
-import uuid
 from dataclasses import dataclass, field, asdict
 from enum import Enum
 from typing import Any, Union
 
 import networkx as nx
-from networkx.readwrite import json_graph
 
 from hammer.logging import HammerVLSILogging
 from hammer.vlsi.cli_driver import CLIDriver
 
 
 class Status(Enum):
-    """Represents the status of a node in the flowgraph.
-    """
+    """Represents the status of a node in the flowgraph."""
     NOT_RUN    = "NOT_RUN"
     RUNNING    = "RUNNING"
     INCOMPLETE = "INCOMPLETE"
@@ -39,18 +36,17 @@ class Node:
     Returns:
         Node: Complete description of an action.
     """
-    action:            str
-    tool:              str
-    pull_dir:          str
-    push_dir:          str
-    required_inputs:   list[str]
-    required_outputs:  list[str]
-    status:            Status    = Status.NOT_RUN
-    # __uuid:            uuid.UUID = field(default_factory=uuid.uuid4)
-    driver:            CLIDriver = field(default_factory=CLIDriver)
-    optional_inputs:   list[str] = field(default_factory=list)
-    optional_outputs:  list[str] = field(default_factory=list)
-    step_controls:     dict[str, str] = field(default_factory=lambda: {
+    action:           str
+    tool:             str
+    pull_dir:         str
+    push_dir:         str
+    required_inputs:  list[str]
+    required_outputs: list[str]
+    status:           Status    = Status.NOT_RUN
+    driver:           CLIDriver = field(default_factory=CLIDriver)
+    optional_inputs:  list[str] = field(default_factory=list)
+    optional_outputs: list[str] = field(default_factory=list)
+    step_controls:    dict[str, str] = field(default_factory=lambda: {
         "start_before_step": "",
         "start_after_step": "",
         "stop_before_step": "",
@@ -204,7 +200,7 @@ class Graph:
                         parent.push_dir,
                         child.pull_dir,
                         parent.required_outputs,
-                        [f"{aux_action}-out.json"],
+                        child.required_inputs,
                     )
                     changes.append((parent_idx, child_idx, aux_node))
 
@@ -213,7 +209,7 @@ class Graph:
             parent, children = list(edge_list_copy.items())[parent_idx]
 
             child = children[child_idx]
-            child.required_inputs = aux_node.required_outputs
+            child.required_inputs.extend(aux_node.required_outputs)
 
             children[child_idx] = aux_node
             if aux_node not in edge_list_copy:
@@ -299,13 +295,6 @@ class Graph:
             ctxt.fatal(f"Step {node.action} failed")
         return code
 
-    def to_json(self) -> dict:
-        """Encodes a graph as a JSON string.
-
-        Returns:
-            str: JSON dump of a flowgraph.
-        """
-        return json_graph.node_link_data(self.networkx)
 
     def to_mermaid(self) -> str:
         """Converts the flowgraph into Mermaid format for visualization.

--- a/tests/test_flowgraph.py
+++ b/tests/test_flowgraph.py
@@ -1,11 +1,9 @@
-import json
 import os
 import tempfile
 import unittest
 from textwrap import dedent
 
 import networkx as nx
-import pytest
 
 from hammer.vlsi.cli_driver import (
     CLIDriver,
@@ -13,7 +11,6 @@ from hammer.vlsi.cli_driver import (
     HammerToolHookAction
 )
 
-from hammer import flowgraph
 from hammer.flowgraph import convert_to_acyclic, Graph, Node, Status
 from hammer.logging import HammerVLSILogging
 
@@ -469,49 +466,6 @@ class TestFlowgraph(unittest.TestCase):
                 else:
                     self.assertTrue(os.path.exists(file))
 
-    @pytest.mark.skip
-    def test_encode_decode(self) -> None:
-        """
-        Test that a flowgraph can be encoded and decoded.
-        """
-        HammerVLSILogging.clear_callbacks()
-        HammerVLSILogging.add_callback(HammerVLSILogging.callback_buffering)
-
-        with tempfile.TemporaryDirectory() as td:
-            os.mkdir(os.path.join(td, "syn_dir"))
-            os.mkdir(os.path.join(td, "par_dir"))
-
-            with open(os.path.join(td, "syn_dir", "syn-in.yml"), 'w', encoding="utf-8") as tf1:
-                tf1.write(MOCK_CFG)
-                
-            syn = Node(
-                "syn", "nop",
-                os.path.join(td, "syn_dir"), os.path.join(td, "s2p_dir"),
-                ["syn-in.yml"],
-                ["syn-out.json"],
-            )
-            s2p = Node(
-                "syn-to-par", "nop",
-                os.path.join(td, "s2p_dir"), os.path.join(td, "par_dir"),
-                ["syn-out.json"],
-                ["s2p-out.json"],
-            )
-            par = Node(
-                "par", "nop",
-                os.path.join(td, "par_dir"), os.path.join(td, "out_dir"),
-                ["s2p-out.json"],
-                ["par-out.json"],
-            )
-            g = Graph({
-                syn: [s2p],
-                s2p: [par],
-                par: []
-            })
-
-            out = json.dumps(g.to_json(), cls=flowgraph.NodeEncoder)
-            g_dec = json.loads(out, object_hook=flowgraph.as_node)
-            # print(g.to_json())
-            # print(json_graph.node_link_graph(g_dec).nodes)
 
 class NodeDummyDriver(CLIDriver):
     def get_extra_synthesis_hooks(self) -> list[HammerToolHookAction]:


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
This PR fixes several small bugs with the flowgraph frontend:
- If required output is set to <action>-output-full.json (like in Makefiles), it overwrites the full db with that of <action>-output.json (reduced)
- Child nodes’ required inputs get overridden by auto-inserted X-to-Y output, but we need to be able to have additional inputs

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [x] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
