### PR TITLE
Fixing qrc tech file read bug in

### DIFF
--- a/hammer/synthesis/genus/__init__.py
+++ b/hammer/synthesis/genus/__init__.py
@@ -229,7 +229,7 @@ class Genus(HammerSynthesisTool, CadenceTool):
             hammer_tech.filters.qrc_tech_filter
         ], hammer_tech.HammerTechnologyUtils.to_plain_item)
         verbose_append("set_db qrc_tech_file {{ {files} }}".format(
-            files=" ".join(qrc_files)
+            files=qrc_files[0]
         ))
 
         # Quit when ispatial is used with sky130

--- a/hammer/synthesis/genus/defaults.yml
+++ b/hammer/synthesis/genus/defaults.yml
@@ -13,7 +13,7 @@ synthesis.genus:
   # High effort:     Provides the best QoR at the cost of runtime.  Requires Genus_Physical_Opt license.
   # Medium effort:   Offers the best trade-off between the runtime and QoR and turns legalization off by default.  
   # None:            Will result in the best runtime.  Works with all base Genus products.
-  phys_flow_effort: "medium"
+  phys_flow_effort: "none"
 
   # Generate the TCL file but do not run it yet.
   generate_only: false


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
Hammer flow breaks on the physical-aware design flow in genus because genus only allows one file to be read for the qrc_tech_file attribute. To fix this, we have set this to always read the first index. We have also set the default value of the phys_flow_effort key to be none, and let the users decide the setting in their yml inputs.
**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [x] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
