### PR TITLE
Write_db is not required for non physical aware flow

### DIFF
--- a/hammer/synthesis/genus/__init__.py
+++ b/hammer/synthesis/genus/__init__.py
@@ -229,7 +229,7 @@ class Genus(HammerSynthesisTool, CadenceTool):
             hammer_tech.filters.qrc_tech_filter
         ], hammer_tech.HammerTechnologyUtils.to_plain_item)
         verbose_append("set_db qrc_tech_file {{ {files} }}".format(
-            files=" ".join(qrc_files)
+            files=qrc_files[0]
         ))
 
         # Quit when ispatial is used with sky130

--- a/hammer/synthesis/genus/__init__.py
+++ b/hammer/synthesis/genus/__init__.py
@@ -472,7 +472,8 @@ set_db hinst:{inst} .preserve true
             verbose_append("write_design -innovus {hier_flag} -gzip_files {top}".format(
                 hier_flag="-hierarchical" if is_hier else "", top=top))
 
-        verbose_append("write_db -common")
+        if self.get_setting("synthesis.genus.phys_flow_effort").lower() != "none":
+            verbose_append("write_db -common")
         self.ran_write_outputs = True
 
         return True

--- a/hammer/synthesis/genus/defaults.yml
+++ b/hammer/synthesis/genus/defaults.yml
@@ -13,7 +13,7 @@ synthesis.genus:
   # High effort:     Provides the best QoR at the cost of runtime.  Requires Genus_Physical_Opt license.
   # Medium effort:   Offers the best trade-off between the runtime and QoR and turns legalization off by default.  
   # None:            Will result in the best runtime.  Works with all base Genus products.
-  phys_flow_effort: "medium"
+  phys_flow_effort: "none"
 
   # Generate the TCL file but do not run it yet.
   generate_only: false


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
The command "write_db -common" is only necessary when doing physical aware flow. But even with the phys_flow_effort set to none, the command is written by default which breaks the genus synthesis flow. Added a condition to not use the command for non physical aware flow.  
**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [x] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
