### PR TITLE
Fix failing print statement warning about lack of power straps

### DIFF
--- a/hammer/vlsi/hammer_vlsi_impl.py
+++ b/hammer/vlsi/hammer_vlsi_impl.py
@@ -964,8 +964,8 @@ class HammerPlaceAndRouteTool(HammerTool):
             copy_fields = ["layer", "direction", "net_order", "width", "spacing", "group_pitch"]
             if len(above_insts) > 0:  # in some cases top_layer == top layer in power strap API
                 above_desc = {k: above_insts[0][k] for k in copy_fields}
-            elif not check_abut:
-                self.logger.error(f"par.power_straps_abutment is False, but you do not have power straps generated on layer {above_insts[0]['layer']} above instances of module {master}! Double check that you will supply power to them.")
+            elif len(insts) > 0 and not check_abut:
+                self.logger.error(f"par.power_straps_abutment is False, but you do not have power straps generated on layer {insts[0]['layer']} above instances of module {master}! Double check that you will supply power to them.")
 
             # Filter for top_layer == layer and valid/bad orientation
             abut_insts = list(filter(lambda m: m["top_layer"] == m["layer"] and

--- a/hammer/vlsi/hammer_vlsi_impl.py
+++ b/hammer/vlsi/hammer_vlsi_impl.py
@@ -965,7 +965,7 @@ class HammerPlaceAndRouteTool(HammerTool):
             if len(above_insts) > 0:  # in some cases top_layer == top layer in power strap API
                 above_desc = {k: above_insts[0][k] for k in copy_fields}
             elif len(insts) > 0 and not check_abut:
-                self.logger.error(f"par.power_straps_abutment is False, but you do not have power straps generated on layer {insts[0]['layer']} above instances of module {master}! Double check that you will supply power to them.")
+                self.logger.error(f"par.power_straps_abutment is False, but power straps for instances of module {master} are being generated on layer {insts[0]['layer']}, which is the same as the module's top layer! Double check that you will supply power to these instances.")
 
             # Filter for top_layer == layer and valid/bad orientation
             abut_insts = list(filter(lambda m: m["top_layer"] == m["layer"] and


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
Fixes a print statement that would always fail
due to `len(above_insts)` being equal to 0.

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [X] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [X] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [X] Did you set `master` as the base branch?
- [X] Did you state the type-of-change/impact?
- [X] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
