### PR TITLE
Make latch_map_file truly optional

### DIFF
--- a/hammer/synthesis/yosys/__init__.py
+++ b/hammer/synthesis/yosys/__init__.py
@@ -249,7 +249,7 @@ class YosysSynth(HammerSynthesisTool, OpenROADTool, TCLTool):
 
     def syn_generic(self) -> bool:
         # TODO: is there a better way to do this? like self.get_setting()
-        if self._database.has_setting("synthesis.yosys.latch_map_file"):
+        if self._database.has_setting("synthesis.yosys.latch_map_file") and self.get_setting('synthesis.yosys.latch_map_file') is not None:
             latch_map = f"techmap -map {self.get_setting('synthesis.yosys.latch_map_file')}"
         else:  # TODO: make the else case better
             latch_map = ""


### PR DESCRIPTION
Right now if a technology doesn't specify the latch map file, "techmap -map None" is written into the generated tcl.

<!-- choose one -->
**Type of change**: Bugfix

<!-- choose one -->
**Impact**:  Change to a Hammer plugin

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
