### PR TITLE
Fix Yosys DFF mapping

### DIFF
--- a/hammer/synthesis/yosys/__init__.py
+++ b/hammer/synthesis/yosys/__init__.py
@@ -270,7 +270,7 @@ class YosysSynth(HammerSynthesisTool, OpenROADTool, TCLTool):
         # Technology mapping of flip-flops
         """)
         for liberty_file in self.liberty_files_tt.split():
-            self.verbose_append(f"dfflibmap -map-only -liberty {liberty_file}")
+            self.verbose_append(f"dfflibmap -liberty {liberty_file}")
         self.verbose_append("opt")
 
         self.write_sdc_file()


### PR DESCRIPTION
Remove `-map-only` flag that was breaking synthesis, causing many DFFs to be emitted as Yosys internal abstract cells instead of being mapped to the available DFF cells.

<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] Change to core Hammer
- [x] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
