### PR TITLE
Distinct `run_genus` synthesis step, ICV LVS blackbox support, and Virtuoso netlist export support

### DIFF
--- a/hammer/lvs/icv/__init__.py
+++ b/hammer/lvs/icv/__init__.py
@@ -185,6 +185,11 @@ class ICVLVS(HammerLVSTool, SynopsysTool):
             config_rs = self.get_setting("lvs.icv.config_runset")  # type: Optional[str]
             if config_rs is not None:
                 f.write(" -runset_config " + config_rs)
+
+            # Equivalence files
+            equiv_files = self.get_setting("lvs.icv.equiv_files")  # type: Optional[str]
+            if equiv_files is not None:
+                f.write(" -e " + equiv_files)
         return True
 
     @property

--- a/hammer/synthesis/genus/__init__.py
+++ b/hammer/synthesis/genus/__init__.py
@@ -91,7 +91,8 @@ class Genus(HammerSynthesisTool, CadenceTool):
             self.add_tieoffs,
             self.write_regs,
             self.generate_reports,
-            self.write_outputs
+            self.write_outputs,
+            self.run_genus
         ]
         if self.get_setting("synthesis.inputs.retime_modules"):
             steps_methods.insert(1, self.retime_modules)
@@ -112,8 +113,7 @@ class Genus(HammerSynthesisTool, CadenceTool):
 
     def do_post_steps(self) -> bool:
         assert super().do_post_steps()
-        return self.run_genus()
-
+        return True
     @property
     def mapped_v_path(self) -> str:
         return os.path.join(self.run_dir, "{}.mapped.v".format(self.top_module))
@@ -477,7 +477,7 @@ set_db hinst:{inst} .preserve true
         self.ran_write_outputs = True
 
         return True
-
+    
     def run_genus(self) -> bool:
         verbose_append = self.verbose_append
 
@@ -486,13 +486,13 @@ set_db hinst:{inst} .preserve true
         verbose_append("quit")
 
         # Create synthesis script.
-        syn_tcl_filename = os.path.join(self.run_dir, "syn.tcl")
-        self.write_contents_to_path("\n".join(self.output), syn_tcl_filename)
+        self.syn_tcl_filename = os.path.join(self.run_dir, "syn.tcl")
+        self.write_contents_to_path("\n".join(self.output), self.syn_tcl_filename)
 
         # Build args.
         args = [
             self.get_setting("synthesis.genus.genus_bin"),
-            "-f", syn_tcl_filename,
+            "-f", self.syn_tcl_filename,
             "-no_gui"
         ]
 

--- a/hammer/utils/__init__.py
+++ b/hammer/utils/__init__.py
@@ -391,7 +391,7 @@ def get_filetype(filename: str) -> HammerFiletype:
     if len(split) == 1:
         return HammerFiletype.NONE
     extension = split[-1]
-    if extension in ["sp", "spi", "nl", "cir", "spice", "cdl"]:
+    if extension in ["sp", "spi", "nl", "cir", "spice", "cdl", "net"]:
         return HammerFiletype.SPICE
     elif extension in ["v", "sv", "vh"]:
         return HammerFiletype.VERILOG


### PR DESCRIPTION
Commit: [/synthesis/genus make run_genus a distinct step](https://github.com/ucb-bar/hammer/commit/d326d697153b13142c8f757dd7dfc0ba6b0d9cd3)

- This is useful/necessary for hooks which inject behaviors AFTER the syn.tcl file has been generated.

Commit: [lvs/icv add lvs.icv.equiv_files for blackboxes](https://github.com/ucb-bar/hammer/commit/20691d568ae1d2e785ab2e36257017066a8c90f2)

- Equivalence files are used by ICV LVS to define LVS boxes/blackboxes. This is an extremeley useful feature for debugging LVS & running LVS quickly.

Commit: [utils/ get_filetype add ".net" as supported ext.](https://github.com/ucb-bar/hammer/commit/b59a3b1a10735d649b12907f24b86e25cecd14df)

- Cadence Virtuoso will produce netlists with the .src.net extension when streaming out schematics as netlists (i.e. when running Calibre nmLVS in Virtuoso)

**Related PRs / Issues**
N/A

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [x] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [x] Change to core Hammer
- [x] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
