### PR TITLE
par/innovus revert gds.gz output gds extension

### DIFF
--- a/hammer/par/innovus/__init__.py
+++ b/hammer/par/innovus/__init__.py
@@ -108,7 +108,7 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
 
     @property
     def output_gds_filename(self) -> str:
-        return os.path.join(self.run_dir, "{top}.gds.gz".format(top=self.top_module))
+        return os.path.join(self.run_dir, "{top}.gds".format(top=self.top_module))
 
     @property
     def output_netlist_filename(self) -> str:


### PR DESCRIPTION
While I understand this is space-efficient to export the final database as a `.gds.gz`, this change (introduced in 5e3cfb37bd5ede464769479889bb6ad38e2509e6 )  significantly breaks the hammer-intech22-plugin fill.mk and icv.mk scripts. See the image below regarding how it breaks the plugin.

This PR reverts the change, so Innovus will export a `.gds` instead of `.gds.gz`

The fix could occur on either the hammer-intech22-plugin side, or here. I leave that to the maintainers to decide which is best ;) 

![Slack_iGwaeFuILT](https://github.com/user-attachments/assets/5cc2e829-cdc1-4c5e-8bb7-16d88e95da57)

**Related PRs / Issues**
N/A

<!-- choose one -->
**Type of change**:
- [x]  Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] Change to core Hammer
- [x] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
