### PR TITLE
Fix Read the Docs build environment

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ build:
     python: '3.10'
   jobs:
     post_create_environment:
-      - pip install poetry==1.4.2 myst-parser
+      - pip install poetry==1.5.1 myst-parser
       - pip install virtualenv==20.23.1
     post_install:
       # VIRTUAL_ENV needs to be set manually for now.

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,8 @@ build:
     python: '3.10'
   jobs:
     post_create_environment:
-      - pip install poetry myst-parser
+      - pip install poetry==1.4.2 myst-parser
+      - pip install virtualenv==20.23.1
     post_install:
       # VIRTUAL_ENV needs to be set manually for now.
       # See https://github.com/readthedocs/readthedocs.org/pull/11152/


### PR DESCRIPTION
Pin the poetry version to 1.5.1, which is known to work well with ReadTheDocs Explicitly install virtualenv 20.23.1, which doesn't have the issue with the 'free_threaded' attribute


**Related PRs / Issues**
Ideally fixes the failing check in https://github.com/ucb-bar/hammer/pull/886
(tangential to the contents of that PR)

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] Change to core Hammer
- [ ] Change to a Hammer plugin
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?
