### PR TITLE
fix: hammer sky130 sram lookup

### DIFF
--- a/hammer/technology/sky130/sram_compiler/__init__.py
+++ b/hammer/technology/sky130/sram_compiler/__init__.py
@@ -55,8 +55,8 @@ class SKY130SRAMGenerator(HammerSRAMGeneratorTool):
 
             found = False
             lib_path: Optional[str] = None
-            for fidelity in ["rcc", "rc", "c"]:
-                lib_path="{b}/{n}/{n}_{c}.{f}.lib".format(b=base_dir,n=sram_name,c=corner_str, f=fidelity)
+            for fidelity in [".rcc", ".rc", ".c", ""]:
+                lib_path="{b}/{n}/{n}_{c}{f}.lib".format(b=base_dir,n=sram_name,c=corner_str, f=fidelity)
                 if os.path.exists(lib_path):
                     found = True
                     break


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

Looking up SRAM macros for the skywater 130 PDK fails on some SRAM libraries because the modules are named differently. This fixes this issue.

This fixes config generation for affected library versions but will not change behavior for non broken ones.

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] Change to core Hammer
- [x] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `master` as the base branch?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
