### PR TITLE
dual clock sdc exist, causing TCLCMD-1594 error

### DIFF
--- a/hammer/common/cadence/__init__.py
+++ b/hammer/common/cadence/__init__.py
@@ -139,12 +139,10 @@ class CadenceTool(HasSDCSupport, HasCPFSupport, HasUPFSupport, TCLTool, HammerTo
         if post_synth_sdc is not None:
             clock_fragment = os.path.join(self.run_dir, "clock_constraints_fragment.sdc")
             sdc_files = [f for f in sdc_files if f != clock_fragment]
+            sdc_files.insert(0, post_synth_sdc)
 
         # Append any custom SDC files.
         sdc_files.extend(self.get_setting("vlsi.inputs.custom_sdc_files"))
-
-        if post_synth_sdc is not None:
-            sdc_files.append(post_synth_sdc)
 
         # TODO: add floorplanning SDC
         if len(sdc_files) > 0:

--- a/hammer/common/cadence/__init__.py
+++ b/hammer/common/cadence/__init__.py
@@ -129,13 +129,20 @@ class CadenceTool(HasSDCSupport, HasCPFSupport, HasUPFSupport, TCLTool, HammerTo
         def append_mmmc(cmd: str) -> None:
             self.verbose_tcl_append(cmd, mmmc_output)
 
+        # Add the post-synthesis SDC, if present.
+        post_synth_sdc = self.post_synth_sdc
+
         sdc_files = self.generate_sdc_files()
+
+        # If a post-synthesis SDC is present it already contains clock definitions,
+        # so drop the Hammer-generated clock fragment to avoid duplicate create_clock.
+        if post_synth_sdc is not None:
+            clock_fragment = os.path.join(self.run_dir, "clock_constraints_fragment.sdc")
+            sdc_files = [f for f in sdc_files if f != clock_fragment]
 
         # Append any custom SDC files.
         sdc_files.extend(self.get_setting("vlsi.inputs.custom_sdc_files"))
 
-        # Add the post-synthesis SDC, if present.
-        post_synth_sdc = self.post_synth_sdc
         if post_synth_sdc is not None:
             sdc_files.append(post_synth_sdc)
 


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [x] Change to core Hammer
- [ ] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `master` as the base branch?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?

Fix duplicate create_clock warning in PAR (TCLCMD-1594/958)

When a post-synthesis SDC (gcd.mapped.sdc) is present, Hammer's MMMC script loaded both clock_constraints_fragment.sdc (generated from vlsi.inputs.clocks) and the synthesis SDC, both of which define create_clock for the same clock. This caused Innovus to warn that the clock definition was being overwritten.

Fix: in generate_mmmc_script(), filter out clock_constraints_fragment.sdc from the SDC list when a post-synthesis SDC is present, since the synthesis SDC already carries the clock definition. The pin constraints fragment is still included. Behavior is unchanged when no post-synthesis SDC exists (e.g. running PAR standalone).